### PR TITLE
Bugfix/missing lines after crash

### DIFF
--- a/dispatcher/data_tracker.py
+++ b/dispatcher/data_tracker.py
@@ -149,7 +149,7 @@ class DataTracker:
                 self._write_checkpoint()
                 self.last_checkpoint_time = now
                 logging.info(f"Checkpoint: last_processed_work_id={self.last_processed_work_id}, "
-                             f"input_offset={self.infile.tell()}, output_offset={self.outfile.tell()}, "
+                             f"input_offset={self.input_offset}, output_offset={self.outfile.tell()}, "
                              f"issued={len(self.issued)}, pending={len(self.pending_write)}, "
                              f"heap_size={len(self.issued_heap)}, expired_reissues={self.expired_reissues}")
 
@@ -192,7 +192,7 @@ class DataTracker:
             # Write a final checkpoint and log status before shutting down.
             self._write_checkpoint()
             logging.info(f"Final checkpoint written: last_processed_work_id={self.last_processed_work_id}, "
-                         f"input_offset={self.infile.tell()}, output_offset={self.outfile.tell()}, "
+                         f"input_offset={self.input_offset}, output_offset={self.outfile.tell()}, "
                          f"issued={len(self.issued)}, pending={len(self.pending_write)}, "
                          f"heap_size={len(self.issued_heap)}, expired_reissues={self.expired_reissues}")
             self.infile.close()

--- a/dispatcher/data_tracker.py
+++ b/dispatcher/data_tracker.py
@@ -177,7 +177,7 @@ class DataTracker:
     def _write_checkpoint(self):
         cp = {
             "last_processed_work_id": self.last_processed_work_id,
-            "input_offset": self.infile.tell(),
+            "input_offset": self.input_offset,
             "output_offset": self.outfile.tell()
         }
         temp_path = self.checkpoint_path + ".tmp"


### PR DESCRIPTION
Fix for https://github.com/LumiOpen/dispatcher/issues/1: 

Ensures input_offset consistency during checkpointing

Before the fix: The checkpoint could record an `input_offset` that included pending work, leading to skipped lines after a restart.

After the fix: The checkpointed `input_offset` only reflects fully processed work, ensuring accurate recovery and no skipped lines.

Added a test that issues some work (items 0,1,2,3,4) and only a part of it is submitted (0,1,2), then checkpoint is written. Restarting the process from checkpoint should start from the tip of the submitted work and the next issued item should be (3) and not (5).