### PR TITLE
Preserve Unicode characters in JSONL output

### DIFF
--- a/examples/inference.py
+++ b/examples/inference.py
@@ -303,7 +303,7 @@ def main():
             # Set results for each work item
             for result in results:
                 work_item = result.pop("_work_item")  # Remove the work item reference
-                work_item.set_result(json.dumps(result))
+                work_item.set_result(json.dumps(result, ensure_ascii=False))
 
             # Submit all results back to the dispatcher
             client.submit_results(work_batch)


### PR DESCRIPTION
## Description
This PR modifies the example inference client to ensure that Unicode characters in model outputs are preserved in their original form rather than being escaped as `\uXXXX` sequences in the output JSONL file.

## Changes
- Added `ensure_ascii=False` to `json.dumps()` call in the example inference client
- No changes are required in the server or DataTracker code because:
  - The DataTracker correctly handles UTF-8 encoded data
  - Files are opened in binary mode and encoded with UTF-8
  - There's no additional JSON serialization that would re-escape Unicode characters

## Testing
Tested with Slovak text input containing characters like "č", "ž", "š" which are now properly preserved in the output file.

