### PR TITLE
Bug fix: Wrong instruction variable used in the prompt

### DIFF
--- a/examples/autoif/src/create_verifiers_input.py
+++ b/examples/autoif/src/create_verifiers_input.py
@@ -26,7 +26,7 @@ def create_verifier_input(instructions_file: str, output_file: str) -> None:
     with open(output_file, 'w') as f:
         for item in instructions:
             prompt = open("model_prompts/create_verifiers_prompt.txt").read().strip()
-            prompt = prompt.format(instruction=instruction)
+            prompt = prompt.format(instruction=item['instruction'])
             data = {
                 'instruction_id': item['id'],
                 'instruction': item['instruction'],


### PR DESCRIPTION
Do not use local variable instruction in the prompt (which will result in using the last read instruction from the file). 
Use the proper item that is looped over.