### PR TITLE
change format of concatenating queries + instructions 

### DIFF
--- a/examples/autoif/src/concat_queries.py
+++ b/examples/autoif/src/concat_queries.py
@@ -54,9 +54,7 @@ def concat_queries(
             selected_queries = random.sample(queries, min(queries_per_instruction, len(queries)))
             
             for query in selected_queries:
-                prompt = f"""Please answer the query strictly following the instruction.
-[instruction] {instruction}
-[Query] {query}"""
+                prompt = f"""{query} {instruction}"""
                 
                 output = {
                     'instruction': instruction,


### PR DESCRIPTION
Concatenate queries and instruction with the format `"{query} {instruction}"`. This will give us prompts with more diverse wording and syntactic structure.