### PR TITLE
set ensure_ascii=False when dumping results from tasks

### DIFF
--- a/dispatcher/taskmanager/tasksource/dispatcher.py
+++ b/dispatcher/taskmanager/tasksource/dispatcher.py
@@ -96,7 +96,7 @@ class DispatcherTaskSource(TaskSource):
             work_item = context
             
             # Set the result on the work item
-            work_item.set_result(json.dumps(result))
+            work_item.set_result(json.dumps(result, ensure_ascii=False))
             
             # Submit back to the dispatcher
             self.client.submit_results([work_item])

--- a/dispatcher/taskmanager/tasksource/file.py
+++ b/dispatcher/taskmanager/tasksource/file.py
@@ -91,7 +91,7 @@ class FileTaskSource(TaskSource):
             result, context = task.get_result()
             
             # Write to output file
-            self.output_file.write(json.dumps(result) + "\n")
+            self.output_file.write(json.dumps(result, ensure_ascii=False) + "\n")
             self.output_file.flush()
             
             line_number = context.get("line_number", "unknown")


### PR DESCRIPTION
Set ensure_ascii=False when writing results from tasks to json