### PR TITLE
bugfix: correctly handle tasks that fail early without yielding requests

### DIFF
--- a/dispatcher/taskmanager/task/__init__.py
+++ b/dispatcher/taskmanager/task/__init__.py
@@ -1,3 +1,3 @@
 from .base import Task, GeneratorTask
 
-__all__ = ['Task', 'GeneratorTask']
+__all__ = ['Task', 'GeneratorTask', 'TaskFailed']


### PR DESCRIPTION
If a task did not yield any requests before returning, this caused an unhandled bug in task initialization where we assumed tasks would always yield at least one request.  This is now handled correctly.

I additionally added a TaskFailed exception that tasks can raise to report errors in a standard way.