### PR TITLE
Format multi-constraint messages

### DIFF
--- a/examples/autoif/autoif_generator_task.py
+++ b/examples/autoif/autoif_generator_task.py
@@ -5,7 +5,7 @@ import re
 from dispatcher.taskmanager.backend.request import Request, Response
 from dispatcher.taskmanager.task.base import GeneratorTask
 
-from src.utils.response_handler import response_verify, extract_score, construct_scoring_messages
+from src.utils.response_handler import response_verify, extract_score, construct_scoring_messages, format_instructions_with_conjunctions
 
 __all__ = ["GenerateQueryResponsesTask"]
 
@@ -70,7 +70,7 @@ class GenerateQueryResponsesTask(GeneratorTask):
 
         # Handle both "instructions" (list) and "instruction" (string - old version) cases
         instructions = self.data.get("instructions", self.data.get("instruction", ""))
-        instructions_text = ". ".join(instructions) if isinstance(instructions, list) else instructions
+        instructions_text = format_instructions_with_conjunctions(instructions)
 
         messages = [
             {

--- a/examples/autoif/src/utils/response_handler.py
+++ b/examples/autoif/src/utils/response_handler.py
@@ -1,5 +1,5 @@
 import signal
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Union
 import re
 import numpy as np
 import os
@@ -251,3 +251,35 @@ def check_error(response: str, error_code: Optional[str] = None):
                 message=f"Error found in response: {error_value}",
                 error_type="error_in_response"
             )
+
+def format_instructions_with_conjunctions(instructions: Union[str, List[str]]) -> str:
+    """Format instructions with proper conjunctions and capitalization.
+    
+    Args:
+        instructions: Single instruction string or list of instructions
+        
+    Returns:
+        Formatted instruction text with conjunctions
+        
+    Examples:
+        - Single: "Your response should..."
+        - Two: "Your response should... and format your response..."
+        - Three+: "Your response should..., you should... and include..."
+    """
+    if isinstance(instructions, str):
+        return instructions
+    
+    if not instructions:
+        return ""
+    
+    if len(instructions) == 1:
+        return instructions[0]
+    
+    # Lowercase first letter of instructions from second onwards
+    formatted = [instructions[0]] + [instr[0].lower() + instr[1:] if instr else instr 
+                                   for instr in instructions[1:]]
+    
+    if len(formatted) == 2:
+        return f"{formatted[0]} and {formatted[1]}"
+    
+    return ", ".join(formatted[:-1]) + f" and {formatted[-1]}"

--- a/examples/autoif/tests/test_response_handler.py
+++ b/examples/autoif/tests/test_response_handler.py
@@ -19,7 +19,7 @@ sys.path.insert(0, src_dir)
 sys.path.insert(0, autoif_dir)
 sys.path.insert(0, dispatcher_root)
 
-from utils.response_handler import check_error, extract_score
+from utils.response_handler import check_error, extract_score, format_instructions_with_conjunctions
 from dispatcher.taskmanager.task.base import TaskFailed
 
 
@@ -213,6 +213,75 @@ def test_extract_score_error_cases():
             raise TestException(f"'{text}' raised unexpected exception: {e}")
 
 
+def test_format_instructions_single():
+    """Test format_instructions_with_conjunctions with single instruction."""
+    instruction = "Your response should be clear"
+    result = format_instructions_with_conjunctions(instruction)
+    if result != instruction:
+        raise TestException(f"Single string should return as-is, got: {result}")
+    
+    # Test with single item list
+    result = format_instructions_with_conjunctions([instruction])
+    if result != instruction:
+        raise TestException(f"Single item list should return the item, got: {result}")
+
+
+def test_format_instructions_two():
+    """Test format_instructions_with_conjunctions with two instructions."""
+    instructions = [
+        "Your response should be clear",
+        "Your response contains examples"
+    ]
+    expected = "Your response should be clear and your response contains examples"
+    result = format_instructions_with_conjunctions(instructions)
+    if result != expected:
+        raise TestException(f"Expected: {expected}, got: {result}")
+
+
+def test_format_instructions_three_or_more():
+    """Test format_instructions_with_conjunctions with three or more instructions."""
+    instructions = [
+        "Your response should be clear",
+        "Your response is detailed", 
+        "Your response contains examples"
+    ]
+    expected = "Your response should be clear, your response is detailed and your response contains examples"
+    result = format_instructions_with_conjunctions(instructions)
+    if result != expected:
+        raise TestException(f"Expected: {expected}, got: {result}")
+    
+    # Test with four instructions
+    instructions_four = [
+        "Your response should be clear",
+        "Your response is detailed",
+        "Your response contains examples", 
+        "Your response follows format"
+    ]
+    expected_four = "Your response should be clear, your response is detailed, your response contains examples and your response follows format"
+    result_four = format_instructions_with_conjunctions(instructions_four)
+    if result_four != expected_four:
+        raise TestException(f"Expected: {expected_four}, got: {result_four}")
+
+
+def test_format_instructions_edge_cases():
+    """Test format_instructions_with_conjunctions with edge cases."""
+    # Empty list
+    result = format_instructions_with_conjunctions([])
+    if result != "":
+        raise TestException(f"Empty list should return empty string, got: {result}")
+    
+    # Empty string
+    result = format_instructions_with_conjunctions("")
+    if result != "":
+        raise TestException(f"Empty string should return empty string, got: {result}")
+    
+    # List with empty strings
+    result = format_instructions_with_conjunctions(["", ""])
+    expected = " and "
+    if result != expected:
+        raise TestException(f"Expected: '{expected}', got: '{result}'")
+
+
 def run_all_tests():
     """Run all tests manually (for environments without pytest)."""
     test_functions = [
@@ -227,7 +296,11 @@ def run_all_tests():
         test_extract_score_basic,
         test_extract_score_markdown_formatting,
         test_extract_score_multiple_scores,
-        test_extract_score_error_cases
+        test_extract_score_error_cases,
+        test_format_instructions_single,
+        test_format_instructions_two,
+        test_format_instructions_three_or_more,
+        test_format_instructions_edge_cases
     ]
     
     passed = 0


### PR DESCRIPTION
- format constraints with proper language conjunctions in final sft messages 
  - hardcoded for English (uses 'and' conjunction between constraints)
  - TODO for other languages
- tests