### PR TITLE
Fix reading last state from checkpoint

### DIFF
--- a/examples/autoif/src/utils/monitor_slurm_job.sh
+++ b/examples/autoif/src/utils/monitor_slurm_job.sh
@@ -58,8 +58,8 @@ while true; do
       ;;
     COMPLETED)
       echo "$prefix: Job $job_id completed successfully"
-      echo "Waiting $check_interval seconds for file operations to complete..."
-      sleep "$check_interval"
+      echo "Waiting 5 seconds for file operations to complete..."
+      sleep 5
       exit 0
       ;;
     *)


### PR DESCRIPTION
There was a bug for reading the last state and job_id from the state tracker. The fix ensures that the correct job_id is read (from the correct job AUG/VER/RESP) and that it is correctly assigned in the pipeline into MONITOR_JOB_ID