### PR TITLE
Add work completion fix and http debugging

### DIFF
--- a/dispatcher/data_tracker.py
+++ b/dispatcher/data_tracker.py
@@ -90,7 +90,7 @@ class DataTracker:
         Returns True if the input file is exhausted and no pending work remains.
         """
         remaining = os.stat(self.infile_path).st_size - self.infile.tell()
-        return remaining == 0 and len(self.pending_write) == 0
+        return remaining == 0 and len(self.issued) == 0 and len(self.pending_write) == 0
 
 
     def get_work_batch(self, batch_size=1):

--- a/dispatcher/data_tracker.py
+++ b/dispatcher/data_tracker.py
@@ -89,8 +89,9 @@ class DataTracker:
         """
         Returns True if the input file is exhausted and no pending work remains.
         """
-        remaining = os.stat(self.infile_path).st_size - self.infile.tell()
-        return remaining == 0 and len(self.issued) == 0 and len(self.pending_write) == 0
+        with self._state_lock:
+            remaining = os.stat(self.infile_path).st_size - self.infile.tell()
+            return remaining == 0 and len(self.issued) == 0 and len(self.pending_write) == 0
 
 
     def get_work_batch(self, batch_size=1):

--- a/dispatcher/http_protocol.py
+++ b/dispatcher/http_protocol.py
@@ -1,0 +1,130 @@
+import asyncio
+from binascii import hexlify
+from urllib.parse import unquote
+
+import h11
+from uvicorn.protocols.http.h11_impl import (
+    HIGH_WATER_LIMIT,
+    H11Protocol,
+    RequestResponseCycle,
+    service_unavailable,
+)
+
+
+class InvalidRequestLoggingH11Protocol(H11Protocol):
+    """Uvicorn h11 protocol with extra diagnostics for malformed requests.
+
+    FastAPI middleware cannot log these errors because h11 rejects the bytes
+    before an ASGI request exists. This protocol is intentionally opt-in.
+    """
+
+    invalid_http_preview_bytes = 64
+
+    def data_received(self, data: bytes) -> None:
+        preview_size = max(0, self.invalid_http_preview_bytes)
+        if preview_size:
+            current = getattr(self, "_invalid_http_preview", b"")
+            self._invalid_http_preview = (current + data)[:preview_size]
+        super().data_received(data)
+
+    def _format_invalid_http_preview(self) -> tuple[str, str]:
+        data = getattr(self, "_invalid_http_preview", b"")
+        hex_preview = hexlify(data).decode("ascii")
+        ascii_preview = "".join(chr(byte) if 32 <= byte <= 126 else "." for byte in data)
+        return hex_preview, ascii_preview
+
+    def handle_events(self) -> None:
+        while True:
+            try:
+                event = self.conn.next_event()
+            except h11.RemoteProtocolError as exc:
+                msg = "Invalid HTTP request received."
+                hex_preview, ascii_preview = self._format_invalid_http_preview()
+                self.logger.warning(
+                    "%s client=%s server=%s error=%r first_bytes_hex=%s first_bytes_ascii=%r",
+                    msg,
+                    self.client,
+                    self.server,
+                    str(exc),
+                    hex_preview,
+                    ascii_preview,
+                )
+                self.send_400_response(msg)
+                return
+
+            if event is h11.NEED_DATA:
+                break
+
+            elif event is h11.PAUSED:
+                self.flow.pause_reading()
+                break
+
+            elif isinstance(event, h11.Request):
+                self.headers = [(key.lower(), value) for key, value in event.headers]
+                raw_path, _, query_string = event.target.partition(b"?")
+                path = unquote(raw_path.decode("ascii"))
+                full_path = self.root_path + path
+                full_raw_path = self.root_path.encode("ascii") + raw_path
+                self.scope = {
+                    "type": "http",
+                    "asgi": {"version": self.config.asgi_version, "spec_version": "2.3"},
+                    "http_version": event.http_version.decode("ascii"),
+                    "server": self.server,
+                    "client": self.client,
+                    "scheme": self.scheme,
+                    "method": event.method.decode("ascii"),
+                    "root_path": self.root_path,
+                    "path": full_path,
+                    "raw_path": full_raw_path,
+                    "query_string": query_string,
+                    "headers": self.headers,
+                    "state": self.app_state.copy(),
+                }
+                if self._should_upgrade():
+                    self.handle_websocket_upgrade(event)
+                    return
+
+                if self.limit_concurrency is not None and (
+                    len(self.connections) >= self.limit_concurrency or len(self.tasks) >= self.limit_concurrency
+                ):
+                    app = service_unavailable
+                    message = "Exceeded concurrency limit."
+                    self.logger.warning(message)
+                else:
+                    app = self.app
+
+                self._unset_keepalive_if_required()
+
+                self.cycle = RequestResponseCycle(
+                    scope=self.scope,
+                    conn=self.conn,
+                    transport=self.transport,
+                    flow=self.flow,
+                    logger=self.logger,
+                    access_logger=self.access_logger,
+                    access_log=self.access_log,
+                    default_headers=self.server_state.default_headers,
+                    message_event=asyncio.Event(),
+                    on_response=self.on_response_complete,
+                )
+                task = self.loop.create_task(self.cycle.run_asgi(app))
+                task.add_done_callback(self.tasks.discard)
+                self.tasks.add(task)
+
+            elif isinstance(event, h11.Data):
+                if self.conn.our_state is h11.DONE:
+                    continue
+                self.cycle.body += event.data
+                if len(self.cycle.body) > HIGH_WATER_LIMIT:
+                    self.flow.pause_reading()
+                self.cycle.message_event.set()
+
+            elif isinstance(event, h11.EndOfMessage):
+                if self.conn.our_state is h11.DONE:
+                    self.transport.resume_reading()
+                    self.conn.start_next_cycle()
+                    continue
+                self.cycle.more_body = False
+                self.cycle.message_event.set()
+                if self.conn.their_state == h11.MUST_CLOSE:
+                    break

--- a/dispatcher/server.py
+++ b/dispatcher/server.py
@@ -17,6 +17,7 @@ from dispatcher.models import (
     WorkStatus,
 )
 from dispatcher.data_tracker import DataTracker
+from dispatcher.http_protocol import InvalidRequestLoggingH11Protocol
 
 app = FastAPI()
 
@@ -112,6 +113,8 @@ def main():
     parser.add_argument("--max-retries", type=int, default=3, help="Number of times to reissue an entry before writing a tombstone. Set to -1 for infinite retries.")
     parser.add_argument("--host", type=str, default="0.0.0.0", help="Host")
     parser.add_argument("--port", type=int, default=8000, help="Port")
+    parser.add_argument("--log-invalid-http", action="store_true", help="Log client address and first bytes for malformed HTTP requests.")
+    parser.add_argument("--invalid-http-preview-bytes", type=int, default=64, help="Number of malformed request bytes to include when --log-invalid-http is enabled.")
     args = parser.parse_args()
 
     global dt, retry_time
@@ -127,12 +130,18 @@ def main():
     logging.info("Server starting with infile=%s, outfile=%s, checkpoint=%s, retry_time=%d work_timeout=%d, max_retries=%d",
                  args.infile, args.outfile, checkpoint_path, retry_time, args.work_timeout, args.max_retries)
 
+    uvicorn_kwargs = {}
+    if args.log_invalid_http:
+        InvalidRequestLoggingH11Protocol.invalid_http_preview_bytes = args.invalid_http_preview_bytes
+        uvicorn_kwargs["http"] = InvalidRequestLoggingH11Protocol
+
     uvicorn.run(
         app,
         host=args.host,
         port=args.port,
         log_level="warning",
         access_log=False,
+        **uvicorn_kwargs,
     )
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "fastapi",
-        "uvicorn",
+        "uvicorn>=0.34,<0.35",
         "pydantic",
         "requests",
     ],

--- a/tests/test_data_tracker.py
+++ b/tests/test_data_tracker.py
@@ -273,6 +273,19 @@ class TestDataTracker(unittest.TestCase):
         self.assertEqual(reissued[1], r0[1])
         dt.close()
 
+    def test_all_work_complete_false_with_inflight_work(self):
+        """Exhausted input is not complete while issued work is unfinished."""
+        dt = DataTracker(self.infile.name, self.outfile.name, self.checkpoint,
+                         work_timeout=WORK_TIMEOUT, checkpoint_interval=CHECKPOINT_INTERVAL)
+
+        batch = dt.get_work_batch(batch_size=20)
+        self.assertIsNotNone(batch)
+        self.assertFalse(dt.all_work_complete())
+
+        dt.complete_work_batch([(work_id, f"result_{work_id}") for work_id, _ in batch])
+        self.assertTrue(dt.all_work_complete())
+        dt.close()
+
     def test_release_work_increments_retry(self):
         """Released items go through the normal reissue path and increment retry_count."""
         dt = DataTracker(self.infile.name, self.outfile.name, self.checkpoint,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,10 +1,13 @@
 import os
 import tempfile
 import json
+import logging
 import unittest
+import h11
 from fastapi.testclient import TestClient
 import dispatcher.server as server_mod
 from dispatcher.data_tracker import DataTracker
+from dispatcher.http_protocol import InvalidRequestLoggingH11Protocol
 
 class TestServer(unittest.TestCase):
     def setUp(self):
@@ -161,6 +164,36 @@ class TestServer(unittest.TestCase):
         release_data = release_resp.json()
         self.assertEqual(release_data["status"], "OK")
         self.assertEqual(release_data["released_count"], 0)
+
+    def test_invalid_http_logging_protocol_logs_peer_and_preview(self):
+        """The opt-in protocol logs details when h11 rejects request bytes."""
+        class RejectingConnection:
+            def next_event(self):
+                raise h11.RemoteProtocolError("bad request bytes")
+
+        protocol = InvalidRequestLoggingH11Protocol.__new__(InvalidRequestLoggingH11Protocol)
+        protocol.conn = RejectingConnection()
+        protocol.logger = logging.getLogger("uvicorn.error")
+        protocol.client = ("10.0.0.1", 12345)
+        protocol.server = ("10.0.0.2", 9999)
+        protocol._invalid_http_preview = b"\x16\x03\x01bad"
+        protocol.sent_400 = None
+
+        def send_400_response(msg):
+            protocol.sent_400 = msg
+
+        protocol.send_400_response = send_400_response
+
+        with self.assertLogs("uvicorn.error", level="WARNING") as logs:
+            protocol.handle_events()
+
+        output = "\n".join(logs.output)
+        self.assertEqual(protocol.sent_400, "Invalid HTTP request received.")
+        self.assertIn("Invalid HTTP request received.", output)
+        self.assertIn("client=('10.0.0.1', 12345)", output)
+        self.assertIn("server=('10.0.0.2', 9999)", output)
+        self.assertIn("first_bytes_hex=160301626164", output)
+        self.assertIn("first_bytes_ascii=", output)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Three issues in this PR:

1. There was an issue in the input file completion logic that would cause the file to show as complete while there was still work in flight.  Added a test case that failed as expected, then fixed the logic. The test case passes now.

2. We should hold the lock while checking completion status.  Added locking to the call. 

3. Added an optional flag to dispatcher server --log-invalid-http to patch uvicorn so that we can log more detail about the invalid HTTP requests we're seeing, including the host they were received from the and the initial part of the content.  My theory is this is an https request being sent to our http server, which is the sort of thing that might cause an invalid http request error.   By default we log only the first 64 bytes in hex (in case it's binary data like an https negotiation), but the number of bytes logged is controllable with --invalid-http-preview-bytes <N>

I think the logic & locking fixes are right, and it seems straightforward to me, but please give it a close look. 