### PR TITLE
Gracefully stop server on completion

### DIFF
--- a/dispatcher/server.py
+++ b/dispatcher/server.py
@@ -3,7 +3,6 @@ import uvicorn
 import logging
 import threading
 import time
-import sys
 from fastapi import FastAPI, Query, Body
 from pydantic import BaseModel
 
@@ -22,16 +21,19 @@ from dispatcher.http_protocol import InvalidRequestLoggingH11Protocol
 app = FastAPI()
 
 dt = None            # Global DataTracker
+server = None        # Global uvicorn.Server, set in main()
 retry_time = 300     # default wait time
 shutdown_interval = 5
 
 def background_shutdown():
     while True:
         time.sleep(shutdown_interval)
-        global dt
+        global dt, server
         if dt is not None and dt.all_work_complete():
             logging.info("All work complete. Shutting down server.")
-            sys.exit(0)
+            if server is not None:
+                server.should_exit = True
+            return
 
 @app.on_event("startup")
 def startup_event():
@@ -117,7 +119,7 @@ def main():
     parser.add_argument("--invalid-http-preview-bytes", type=int, default=64, help="Number of malformed request bytes to include when --log-invalid-http is enabled.")
     args = parser.parse_args()
 
-    global dt, retry_time
+    global dt, retry_time, server
     retry_time = args.retry
     checkpoint_path = args.checkpoint if args.checkpoint else args.outfile + ".checkpoint"
     dt = DataTracker(
@@ -135,7 +137,7 @@ def main():
         InvalidRequestLoggingH11Protocol.invalid_http_preview_bytes = args.invalid_http_preview_bytes
         uvicorn_kwargs["http"] = InvalidRequestLoggingH11Protocol
 
-    uvicorn.run(
+    config = uvicorn.Config(
         app,
         host=args.host,
         port=args.port,
@@ -143,6 +145,8 @@ def main():
         access_log=False,
         **uvicorn_kwargs,
     )
+    server = uvicorn.Server(config)
+    server.run()
 
 if __name__ == "__main__":
     main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 import json
 import logging
+import threading
 import unittest
 import h11
 from fastapi.testclient import TestClient
@@ -194,6 +195,37 @@ class TestServer(unittest.TestCase):
         self.assertIn("server=('10.0.0.2', 9999)", output)
         self.assertIn("first_bytes_hex=160301626164", output)
         self.assertIn("first_bytes_ascii=", output)
+
+
+class TestServerShutdown(unittest.TestCase):
+    def test_background_shutdown_signals_uvicorn_server(self):
+        """Completion watcher should ask uvicorn to exit, not just its thread."""
+        class CompleteTracker:
+            def all_work_complete(self):
+                return True
+
+        class FakeServer:
+            should_exit = False
+
+        old_dt = server_mod.dt
+        old_server = server_mod.server
+        old_interval = server_mod.shutdown_interval
+        fake_server = FakeServer()
+        try:
+            server_mod.dt = CompleteTracker()
+            server_mod.server = fake_server
+            server_mod.shutdown_interval = 0.01
+
+            thread = threading.Thread(target=server_mod.background_shutdown)
+            thread.start()
+            thread.join(timeout=1)
+
+            self.assertFalse(thread.is_alive())
+            self.assertTrue(fake_server.should_exit)
+        finally:
+            server_mod.dt = old_dt
+            server_mod.server = old_server
+            server_mod.shutdown_interval = old_interval
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
We were calling system.exit(0) from a background thread which would only cause that background thread to exit and would still leave the server running. Instead, we should tell the uvicorn server to exit.