### PR TITLE
Warn when work release is incomplete

### DIFF
--- a/dispatcher/taskmanager/cli.py
+++ b/dispatcher/taskmanager/cli.py
@@ -42,6 +42,7 @@ from dispatcher.taskmanager.backend import VLLMBackendManager
 from dispatcher.taskmanager.taskmanager import TaskManager
 from dispatcher.taskmanager.tasksource import FileTaskSource, DispatcherTaskSource
 from dispatcher.taskmanager.task.base import Task
+from dispatcher.models import WorkStatus
 
 logger = logging.getLogger(__name__)
 
@@ -97,7 +98,16 @@ def _install_signal_handlers(backend: VLLMBackendManager, task_manager: TaskMana
         if work_ids and isinstance(task_source, DispatcherTaskSource):
             try:
                 resp = task_source.client.release_work(work_ids)
-                logger.info("Released %d/%d work items", resp.released_count, len(work_ids))
+                if resp.status != WorkStatus.OK or resp.released_count != len(work_ids):
+                    logger.warning(
+                        "Released %d/%d in-flight work items during shutdown; status=%s. "
+                        "Unreleased items will be retried after dispatcher timeout.",
+                        resp.released_count,
+                        len(work_ids),
+                        resp.status,
+                    )
+                else:
+                    logger.info("Released %d/%d work items", resp.released_count, len(work_ids))
             except Exception:
                 logger.exception(
                     "Error while releasing work items during signal %d handling",

--- a/dispatcher/taskmanager/tasksource/dispatcher.py
+++ b/dispatcher/taskmanager/tasksource/dispatcher.py
@@ -97,8 +97,17 @@ class DispatcherTaskSource(TaskSource):
 
             # If the task should be retried, release the work item back to the dispatcher
             if task.should_retry():
-                self.client.release_work([work_item.work_id])
-                self.logger.debug(f"Released work item {work_item.work_id} for retry: {task.retry_reason}")
+                resp = self.client.release_work([work_item.work_id])
+                if resp.status != WorkStatus.OK or resp.released_count != 1:
+                    self.logger.warning(
+                        "Failed to release retry work item %s immediately; status=%s released_count=%s. "
+                        "It will be retried after dispatcher timeout.",
+                        work_item.work_id,
+                        resp.status,
+                        resp.released_count,
+                    )
+                else:
+                    self.logger.debug(f"Released work item {work_item.work_id} for retry: {task.retry_reason}")
                 return
 
             work_item.set_result(json.dumps(result, ensure_ascii=False))


### PR DESCRIPTION
Add some logging when work release fails, just for diagnostic reasons.