### PR TITLE
Add retry metadata to work responses

### DIFF
--- a/dispatcher/data_tracker.py
+++ b/dispatcher/data_tracker.py
@@ -207,6 +207,14 @@ class DataTracker:
                     logging.info(f"Released work item {work_id} for immediate reissue.")
         return released
 
+    def get_retry_metadata(self, work_id):
+        with self._state_lock:
+            if work_id not in self.issued:
+                return 0, self.max_retries
+
+            _, _, retry_count, _ = self.issued[work_id]
+            return retry_count, self.max_retries
+
     def _track_issued_work(self, when, content, input_offset, work_id=None):
         if work_id is None:
             # This is brand new work.

--- a/dispatcher/models.py
+++ b/dispatcher/models.py
@@ -12,6 +12,8 @@ class WorkItem(BaseModel):
     work_id: int
     content: str
     result: Optional[str] = None  # This can be filled in after processing.
+    retry_count: int = 0
+    max_retries: Optional[int] = None
 
     def set_result(self, new_result: str):
         """Optional convenience method to store a result directly on the item."""

--- a/dispatcher/server.py
+++ b/dispatcher/server.py
@@ -51,7 +51,17 @@ def get_work(batch_size: int = Query(1, ge=1)):
         
     batch = dt.get_work_batch(batch_size)
     if batch:
-        items = [WorkItem(work_id=i[0], content=i[1]) for i in batch]
+        items = []
+        for work_id, content in batch:
+            retry_count, max_retries = dt.get_retry_metadata(work_id)
+            items.append(
+                WorkItem(
+                    work_id=work_id,
+                    content=content,
+                    retry_count=retry_count,
+                    max_retries=max_retries,
+                )
+            )
         return BatchWorkResponse(status=WorkStatus.OK, items=items)
     else:
         # The input is exhausted but pending work not done => "retry"

--- a/dispatcher/taskmanager/task/base.py
+++ b/dispatcher/taskmanager/task/base.py
@@ -77,6 +77,49 @@ class Task(ABC):
         """Human-readable reason for the retry, or empty string if none."""
         return ""
 
+    # -- result helpers ----------------------------------------------------
+    #
+    # The helpers below encode the dispatcher's conventional result schema
+    # (success / error / retry_count / max_retries) in one
+    # place so individual tasks do not hand-assemble the return dict. If the
+    # schema ever changes, update build_result and every task picks it up.
+
+    def is_last_retry_attempt(self) -> bool:
+        """True when this attempt is the last one the dispatcher will issue.
+
+        Returns False when retry metadata is unavailable (e.g. FileTaskSource)
+        or when retries are unlimited (max_retries == -1).
+        """
+        retry_count = getattr(self.context, "retry_count", 0) or 0
+        max_retries = getattr(self.context, "max_retries", None)
+        if max_retries is None or max_retries == -1:
+            return False
+        return retry_count >= max_retries
+
+    def build_result(
+        self,
+        *,
+        success: bool = True,
+        error: Optional[str] = None,
+        **payload: Any,
+    ) -> Dict[str, Any]:
+        """Construct a result dict with the standard dispatcher fields filled in.
+
+        Layering (last wins): self.data -> standard fields -> caller payload.
+        Retry metadata is included automatically when the task source provides it.
+        """
+        result: Dict[str, Any] = {**self.data, "success": success}
+        if error is not None:
+            result["error"] = error
+        retry_count = getattr(self.context, "retry_count", None)
+        max_retries = getattr(self.context, "max_retries", None)
+        if retry_count is not None:
+            result["retry_count"] = retry_count
+        if max_retries is not None:
+            result["max_retries"] = max_retries
+        result.update(payload)
+        return result
+
 ###############################################################################
 # Generator‑powered task helper
 ###############################################################################

--- a/tests/taskmanager/test_generator_task.py
+++ b/tests/taskmanager/test_generator_task.py
@@ -254,6 +254,121 @@ class TestGeneratorTaskLifecycle(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Tests for Task.is_last_retry_attempt() and Task.build_result()
+# ---------------------------------------------------------------------------
+
+class _RetryCtx:
+    """Stand-in for dispatcher.models.WorkItem with retry metadata."""
+    def __init__(self, retry_count=0, max_retries=None):
+        self.retry_count = retry_count
+        self.max_retries = max_retries
+
+
+def _make_task(data=None, context=None):
+    """Build a minimal initialized Task instance to exercise the helpers."""
+    return MockGeneratorTaskForLifecycle(
+        data=data if data is not None else {},
+        mode="immediate_return",
+        context=context,
+    )
+
+
+class TestIsLastRetryAttempt(unittest.TestCase):
+    """is_last_retry_attempt() reads retry_count / max_retries off self.context."""
+
+    def test_returns_false_when_metadata_unavailable(self):
+        # context=None, FileTaskSource-style dict context, missing max_retries,
+        # and an explicit None retry_count must all return False without crashing.
+        for ctx in (
+            None,
+            {"line_number": 5},
+            _RetryCtx(retry_count=2, max_retries=None),
+            _RetryCtx(retry_count=None, max_retries=3),
+        ):
+            with self.subTest(ctx=ctx):
+                self.assertFalse(_make_task(context=ctx).is_last_retry_attempt())
+
+    def test_returns_false_for_unlimited_retries(self):
+        # max_retries == -1 means infinite retries; no "last" attempt exists.
+        task = _make_task(context=_RetryCtx(retry_count=99, max_retries=-1))
+        self.assertFalse(task.is_last_retry_attempt())
+
+    def test_threshold_behavior(self):
+        # False before the last attempt, True at the threshold, True past it
+        # (defensive), and True when max_retries=0 means "no retries allowed".
+        cases = [
+            (2, 3, False),
+            (3, 3, True),
+            (5, 3, True),
+            (0, 0, True),
+        ]
+        for retry_count, max_retries, expected in cases:
+            with self.subTest(retry_count=retry_count, max_retries=max_retries):
+                task = _make_task(context=_RetryCtx(retry_count, max_retries))
+                self.assertEqual(task.is_last_retry_attempt(), expected)
+
+
+class TestBuildResult(unittest.TestCase):
+    """build_result() assembles the dispatcher's standard result schema."""
+
+    def test_default_success_with_payload(self):
+        # success defaults to True; data is spread in; payload is merged.
+        task = _make_task(data={"prompt": "hi"})
+        self.assertEqual(
+            task.build_result(translated="HI", score=0.9),
+            {"prompt": "hi", "success": True, "translated": "HI", "score": 0.9},
+        )
+        # Empty data still yields a valid minimal result.
+        self.assertEqual(_make_task().build_result(), {"success": True})
+
+    def test_failure_with_error_and_partial_payload(self):
+        task = _make_task(data={"prompt": "hi"})
+        self.assertEqual(
+            task.build_result(success=False, error="boom", partial="HE"),
+            {"prompt": "hi", "success": False, "error": "boom", "partial": "HE"},
+        )
+        # error=None must be omitted, not serialized as null.
+        self.assertNotIn("error", task.build_result(success=False))
+
+    def test_retry_metadata_included_with_edge_values(self):
+        # retry_count=0 (first attempt) and max_retries=-1 (unlimited) are both
+        # meaningful and must surface in the result, not be dropped by a truthy check.
+        for retry_count, max_retries in [(2, 3), (0, 3), (5, -1)]:
+            with self.subTest(retry_count=retry_count, max_retries=max_retries):
+                task = _make_task(context=_RetryCtx(retry_count, max_retries))
+                result = task.build_result()
+                self.assertEqual(result["retry_count"], retry_count)
+                self.assertEqual(result["max_retries"], max_retries)
+
+    def test_retry_metadata_omitted_when_context_lacks_attrs(self):
+        for ctx in (None, {"line_number": 0}):
+            with self.subTest(ctx=ctx):
+                result = _make_task(context=ctx).build_result()
+                self.assertNotIn("retry_count", result)
+                self.assertNotIn("max_retries", result)
+
+    def test_payload_overrides_data_and_standard_fields(self):
+        # Last-write-wins: caller payload trumps both self.data and the auto-filled
+        # retry fields, so a task can override defaults when it has better info.
+        task = _make_task(
+            data={"prompt": "original"},
+            context=_RetryCtx(retry_count=2, max_retries=3),
+        )
+        result = task.build_result(prompt="overridden", retry_count=999)
+        self.assertEqual(result["prompt"], "overridden")
+        self.assertEqual(result["retry_count"], 999)
+
+    def test_success_and_error_are_keyword_only(self):
+        # Guards against positional misuse like build_result(False, "oops")
+        # silently swapping argument meaning.
+        task = _make_task()
+        with self.assertRaises(TypeError):
+            task.build_result(False)  # type: ignore[misc]
+        with self.assertRaises(TypeError):
+            task.build_result(True, "oops")  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
 # Exports for use in other test modules
 # ---------------------------------------------------------------------------
 __all__ = [


### PR DESCRIPTION
## Summary
- Include `retry_count` and `max_retries` on dispatched work items so workers can see retry state.
- Read retry metadata from `DataTracker` when building `/work` responses.
- Add `Task.is_last_retry_attempt()` and `Task.build_result()` helpers so task implementations can consume the new retry fields and consistently construct their return dict in one place.

## Motivation
Tasks using the `TaskRetry` mechanism need to know when they are on the final retry attempt. This lets a task choose to write an incomplete but useful result to the output file instead of raising another retry that will eventually become only a dispatcher tombstone.

This is useful for flows such as prompt translation. Partial results can still be valuable even when task post-processing checks fail or generation returns an error, because those partial outputs may be useful for future datasets or debugging.

## Helpers added to `Task`

- `is_last_retry_attempt() -> bool` — true when `retry_count >= max_retries`. Returns false when retry metadata is unavailable (e.g. `FileTaskSource`) or when retries are unlimited (`max_retries == -1`).
- `build_result(*, success=True, error=None, **payload) -> dict` — assembles `{**self.data, "success": ..., [error], [retry_count, max_retries from context], **payload}`. Centralizes the dispatcher's result schema in one place; tasks no longer hand-roll the dict.

Both are optional — existing tasks that return their own dicts keep working unchanged.

## Usage pattern

```python
try:
    translated_prompt = self._response_text_or_retry(response)
except TaskRetry as exc:
    if self.is_last_retry_attempt():
        return self.build_result(
            success=False,
            error=str(exc),
            translated_prompt=translated_prompt_so_far,
        )
    raise

return self.build_result(translated_prompt=translated_prompt)
```