### PR TITLE
Add examples/inference: dispatcher inference example with 5 profiles

### DIFF
--- a/examples/inference/CLAUDE.md
+++ b/examples/inference/CLAUDE.md
@@ -1,0 +1,38 @@
+# Inference example notes
+
+## TensorWave epilog kills sibling jobs (workaround)
+
+If the user reports their dispatcher server or workers were suddenly killed
+on TensorWave, the cause is almost always the cluster epilog at
+`/itshared/silo16/slurm_config/epilog.sh`:
+
+- Checks for sibling jobs at the cgroup v1 path
+  (`/sys/fs/cgroup/cpuset/slurm/uid_$UID/job_*`).
+- TensorWave is on cgroup v2 → directory missing → sibling list is empty.
+- The "are there other jobs of mine on this node?" loop never runs, so the
+  script falls through to `kill -9` on every "leftover" process owned by the
+  user — including their dispatcher server and workers.
+
+The bug has been reported to cluster ops but is not yet fixed.
+
+### Recommended workflow (documented in README.md)
+
+1. Run the dispatcher server as a SLURM job
+   (`jobs/launch_dispatcher_server.sh`), not on the login node.
+2. Pin 8 non-preemptible workers (one GPU each) to the server's node to fill
+   it, so no other short job of the user can land there and trigger the
+   epilog kill.
+3. Run any extra workers as `--qos=backlog --requeue` jobs on other nodes —
+   epilog kills on those nodes only affect that node, not the server.
+
+**Trade-off**: one full GPU node is held by the inference workload for the
+duration of the run. Only flag this trade-off if the user has not already
+acknowledged it.
+
+Do not recommend running the server on the login node (`start_dispatcher_server.sh`
+without `--run-server`) while this workaround is in effect — it loses the
+node-pinning benefit. Login-node mode is fine for short ad-hoc runs but not
+for production-length workloads on TensorWave.
+
+Remove this workaround section once the epilog is fixed (cgroup v2 paths, or
+`squeue -h -u $SLURM_JOB_UID -w $(hostname)` for sibling detection).

--- a/examples/inference/README.md
+++ b/examples/inference/README.md
@@ -1,0 +1,206 @@
+# Dispatcher Inference Example
+
+A shared example for running dispatcher-backed generation tasks over JSONL
+input. It covers plain OpenAI-messages inference, two flavors of reasoning-trace
+translation, and prompt/ground-truth translation. Workers are submitted as
+SLURM jobs and can run as regular or preemptible backlog jobs — they pull work
+from a central dispatcher server, so workers can come and go flexibly without
+losing progress.
+
+## Structure
+
+```
+examples/inference/
+├── README.md
+├── start_dispatcher_server.sh      # login-node tmux launcher for the server
+├── tw_singularity_launcher.sh      # vLLM + worker launcher (TensorWave)
+├── configs/                        # KEY=VALUE shell configs per profile
+├── jobs/
+│   ├── launch_dispatcher_server.sh # sbatch wrapper to run the server on a compute node
+│   ├── launch_dispatcher_worker.sh # sbatch worker job (vLLM + dispatcher worker)
+│   └── pull_vllm_sif.sh            # one-time pull of the vLLM Singularity image
+└── tasks/
+    ├── inference_task.py
+    ├── inference_task_think.py
+    ├── prompt_translation_task.py
+    ├── reasoning_translation_task.py
+    └── reasoning_translation_split_traces_task.py
+```
+
+### Tasks
+
+All five tasks subclass `dispatcher.taskmanager.task.base.GeneratorTask` and use
+the standard result contract:
+
+- `self.build_result(**payload)` to construct the return dict — spreads
+  `self.data`, adds `success: True`, merges your payload, and (when retry
+  metadata is available) includes `retry_count` and `max_retries`.
+- `self.is_last_retry_attempt()` to detect the final retry attempt, so the
+  task can write a partial / errored result instead of raising another
+  `TaskRetry` that would become a dispatcher tombstone.
+
+The translation tasks (`prompt_translation_task`, `reasoning_translation_task`,
+`reasoning_translation_split_traces_task`) wrap `build_result` in a small local
+`_failed_result` helper that adds per-task warning logs, then delegates to the
+base helper for the schema.
+
+| Task | Input shape | Output additions |
+| --- | --- | --- |
+| `InferenceTask` | `messages: [...]` | `response`, `output_messages` |
+| `InferenceTask` (think variant) | `messages: [...]` | `response`, `output_messages` — uses larger context + Qwen-style thinking |
+| `PromptTranslationTask` | `prompt`, `ground_truth` | `translated_prompt`, `translated_ground_truth` |
+| `ReasoningTranslationTask` | `input` (messages), `output` (with `<think>` tags) | `translated_prompt`, `translated_traces` |
+| `ReasoningTranslationSplitTracesTask` | same as above | same, but trace body and answer translated separately then recombined |
+
+### Configs
+
+Per profile there is one server config plus one worker config:
+
+| Profile | Server config | Worker config | Task |
+| --- | --- | --- | --- |
+| Annotations | `dispatcher-server-annotations.conf` | `dispatcher-workers-annotations.conf` | `InferenceTask` |
+| Prompt translation | `dispatcher-server-prompt-translation.conf` | `dispatcher-worker-prompt-translation.conf` | `PromptTranslationTask` |
+| SFT pipeline (stage 5) | `dispatcher-server-sft-pipeline-stage5.conf` | `dispatcher-workers-sft-pipeline-stage5.conf` | `InferenceTask` |
+| Translation | `dispatcher-server-translation.conf` | `dispatcher-workers-translation.conf` | `ReasoningTranslationTask` |
+| Translation (split traces) | `dispatcher-server-translation-split-traces.conf` | `dispatcher-worker-translation-split-traces.conf` | `ReasoningTranslationSplitTracesTask` |
+
+Server configs set `INPUT_FILE`, `OUTPUT_FILE`, `SESSION_NAME`,
+`DISPATCHER_PORT`, `WORK_TIMEOUT`, `MAX_RETRIES`, and `DISPATCHER_PKG`. Worker
+configs set `SERVER_ADDRESS_FILE` (matching the server's `.<SESSION_NAME>`
+file), `TASK`, `MODEL`, `LAUNCHER`, and any vLLM or launcher overrides.
+
+The TensorWave launcher (`tw_singularity_launcher.sh`) accepts overrides such
+as `LAUNCHER_IMG`, `LAUNCHER_HF_HOME`, `LAUNCHER_TORCHINDUCTOR_CACHE`,
+`LAUNCHER_HF_HUB_OFFLINE`, `LAUNCHER_TRANSFORMERS_OFFLINE`, and
+`LAUNCHER_MODELS_BIND_MODE`, so task-specific configs can change container
+behavior without copying the worker script.
+
+This example is configured for the **TensorWave cluster**. To run on **LUMI**,
+point the `LAUNCHER` variable in your worker config to a LUMI-specific
+launcher script instead of `tw_singularity_launcher.sh`.
+
+## Usage
+
+All commands are run from `examples/inference/`.
+
+### 1. Pull the vLLM image (once)
+
+```
+./jobs/pull_vllm_sif.sh
+```
+
+### 2. Start the dispatcher server
+
+There are two ways to run the server. **Pick one** per profile.
+
+#### Option A: login-node tmux session
+
+Fast to start, fine for short-running jobs and ad-hoc work. The server lives
+in a tmux session named after `SESSION_NAME` and can be inspected with
+`--status` / stopped with `--stop`.
+
+```
+./start_dispatcher_server.sh configs/dispatcher-server-annotations.conf
+./start_dispatcher_server.sh configs/dispatcher-server-annotations.conf --status
+./start_dispatcher_server.sh configs/dispatcher-server-annotations.conf --stop
+```
+
+#### Option B: compute-node sbatch job
+
+Preferred for long-running profiles where login-node uptime is unreliable, or
+when the server should not share resources with interactive use. The job
+script is a thin wrapper that calls `start_dispatcher_server.sh ... --run-server`
+inside an allocation.
+
+```
+sbatch jobs/launch_dispatcher_server.sh configs/dispatcher-server-annotations.conf
+```
+
+The server process is identical between the two options — workers connect via
+the `.<SESSION_NAME>` address file regardless of where the server runs.
+
+### 3. Submit workers
+
+A single worker:
+
+```
+sbatch jobs/launch_dispatcher_worker.sh configs/dispatcher-workers-annotations.conf
+```
+
+Preemptible backlog workers as a job array:
+
+```
+sbatch --qos=backlog --requeue --array=0-15 \
+       jobs/launch_dispatcher_worker.sh configs/dispatcher-workers-annotations.conf
+```
+
+The same script works with both submission modes. Each worker spins up a local
+vLLM instance, connects to the dispatcher server, and pulls work items until
+none remain. Because all state lives on the server side, workers can be
+preempted, requeued, or cancelled at any time without data loss. Add or remove
+workers freely while the server is running.
+
+Swap the config path to run any other profile, e.g.:
+
+```
+sbatch jobs/launch_dispatcher_worker.sh configs/dispatcher-worker-translation-split-traces.conf
+```
+
+### Monitor
+
+```
+./start_dispatcher_server.sh configs/dispatcher-server-annotations.conf --status
+```
+
+- Server logs (login-node mode): `logs/dispatcher-server-<session>.*`
+- Server logs (compute-node mode): `logs/dispatcher-server-<jobid>.{out,err}`
+- Worker / vLLM logs: `logs/<jobid>_<array_task_id>.*`
+
+## Workaround: TensorWave epilog kills sibling jobs
+
+> **Temporary — TensorWave only.** Remove this workflow once the cluster
+> epilog at `/itshared/silo16/slurm_config/epilog.sh` is fixed.
+
+When any SLURM job of yours ends on a TensorWave node, the cluster epilog
+SIGKILLs every other process owned by your UID on that node — including your
+dispatcher server and any other running jobs of yours. Root cause: the epilog
+checks for sibling jobs at the cgroup v1 path
+(`/sys/fs/cgroup/cpuset/slurm/uid_$UID/job_*`), but TensorWave is on cgroup
+v2. The directory is missing, the sibling-detection loop sees an empty list,
+and the script falls through to `kill -9` on every "leftover" process owned
+by your UID. Those processes are not leftovers.
+
+### Recommended workflow until the epilog is fixed
+
+The idea is to fully occupy the server's node with your own non-preemptible
+workers, so no shorter sibling job of yours can land there and trigger the
+epilog kill.
+
+1. Start the dispatcher server as a SLURM job (Option B above):
+   ```
+   sbatch jobs/launch_dispatcher_server.sh configs/dispatcher-server-annotations.conf
+   ```
+
+2. Note which node the server landed on:
+   ```
+   squeue --me -n dispatcher-server -o '%i %N %T'
+   ```
+
+3. Submit **8 non-preemptible workers pinned to that node**. With one GPU per
+   worker this fills the node:
+   ```
+   sbatch --nodelist=<server-node> --array=0-7 \
+          jobs/launch_dispatcher_worker.sh configs/dispatcher-workers-annotations.conf
+   ```
+
+4. Submit any additional workers as preemptible backlog jobs on other nodes —
+   if one of these is preempted or finishes, the epilog only affects that
+   other node, not the server's:
+   ```
+   sbatch --qos=backlog --requeue --array=0-15 \
+          jobs/launch_dispatcher_worker.sh configs/dispatcher-workers-annotations.conf
+   ```
+
+**Trade-off**: one full GPU node is held by the inference workload for the
+duration of the run. The benefit is that the server and its co-located
+workers cannot be killed by another short job of yours ending on that node.

--- a/examples/inference/configs/dispatcher-server-annotations.conf
+++ b/examples/inference/configs/dispatcher-server-annotations.conf
@@ -1,0 +1,7 @@
+INPUT_FILE=/shared_silo/scratch/datasets/sft-pipeline-stage3/train.jsonl
+OUTPUT_FILE=/shared_silo/scratch/adamhrin@amd.com/dispatcher_inference/examples/inference/data/sft-pipeline-stage3-train.jsonl
+DISPATCHER_PORT=9999
+SESSION_NAME=dispatcher-server-annotations
+DISPATCHER_PKG=/shared_silo/scratch/adamhrin@amd.com/dispatcher_inference
+WORK_TIMEOUT=180
+MAX_RETRIES=5

--- a/examples/inference/configs/dispatcher-server-prompt-translation.conf
+++ b/examples/inference/configs/dispatcher-server-prompt-translation.conf
@@ -1,0 +1,8 @@
+INPUT_FILE=/shared_silo/scratch/datasets/Dolci-Think-RL-7B/data/train.jsonl
+OUTPUT_FILE=/shared_silo/scratch/adamhrin@amd.com/dispatcher_inference/examples/inference/data/Dolci-Think-RL-7B-prompt-ground-truth-translated-fi.jsonl
+DISPATCHER_PORT=10020
+SESSION_NAME=dispatcher-server-prompt-translation
+DISPATCHER_PKG=/shared_silo/scratch/adamhrin@amd.com/dispatcher_inference
+SKIP_DISPATCHER_INSTALL=1
+WORK_TIMEOUT=7200
+MAX_RETRIES=3

--- a/examples/inference/configs/dispatcher-server-sft-pipeline-stage5.conf
+++ b/examples/inference/configs/dispatcher-server-sft-pipeline-stage5.conf
@@ -1,0 +1,8 @@
+INPUT_FILE=/shared_silo/scratch/rahul.aralikatte@amd.com/sft-data/input-stage5.jsonl
+OUTPUT_FILE=/shared_silo/scratch/rahul.aralikatte@amd.com/sft-data/output-stage5-dispatcher-think.jsonl
+DISPATCHER_PORT=9999
+SESSION_NAME=dispatcher-server-sft-pipeline-stage5
+DISPATCHER_PKG=/shared_silo/scratch/adamhrin@amd.com/dispatcher_inference
+WORK_TIMEOUT=5400
+WORKERS=150
+MAX_RETRIES=3

--- a/examples/inference/configs/dispatcher-server-translation-split-traces.conf
+++ b/examples/inference/configs/dispatcher-server-translation-split-traces.conf
@@ -1,0 +1,7 @@
+INPUT_FILE=/shared_silo/scratch/datasets/Llama-Nemotron-Post-Training-Dataset_SFT_math/SFT/math/math_v1.1.jsonl
+OUTPUT_FILE=/shared_silo/scratch/adamhrin@amd.com/dispatcher_inference/examples/inference/data/sweeps/translation-split-traces.jsonl
+DISPATCHER_PORT=10014
+SESSION_NAME=dispatcher-server-translation-split-traces
+DISPATCHER_PKG=/shared_silo/scratch/adamhrin@amd.com/dispatcher_inference
+WORK_TIMEOUT=10800
+MAX_RETRIES=3

--- a/examples/inference/configs/dispatcher-server-translation.conf
+++ b/examples/inference/configs/dispatcher-server-translation.conf
@@ -1,0 +1,7 @@
+INPUT_FILE=/shared_silo/scratch/datasets/Llama-Nemotron-Post-Training-Dataset_SFT_math/SFT/math/math_v1.1.jsonl
+OUTPUT_FILE=/shared_silo/scratch/adamhrin@amd.com/dispatcher_inference/examples/inference/data/Llama-Nemotron-SFT-math-translated-gemma4-fi.jsonl
+DISPATCHER_PORT=9998
+SESSION_NAME=dispatcher-server-translation
+DISPATCHER_PKG=/shared_silo/scratch/adamhrin@amd.com/dispatcher_inference
+WORK_TIMEOUT=3600
+MAX_RETRIES=3

--- a/examples/inference/configs/dispatcher-worker-prompt-translation.conf
+++ b/examples/inference/configs/dispatcher-worker-prompt-translation.conf
@@ -1,0 +1,13 @@
+SERVER_ADDRESS_FILE=.dispatcher-server-prompt-translation
+DISPATCHER_PKG=/shared_silo/scratch/adamhrin@amd.com/dispatcher_inference
+SKIP_DISPATCHER_INSTALL=1
+LAUNCHER=/shared_silo/scratch/adamhrin@amd.com/dispatcher_inference/examples/inference/tw_singularity_launcher.sh
+TASK=tasks.prompt_translation_task.PromptTranslationTask
+LANGUAGE=fi
+MODEL=/shared_silo/scratch/models/gemma-4-31B-it
+GPUS_PER_TASK=1
+WORKERS=128
+MAX_MODEL_LEN=16384
+PROMPT_TRANSLATION_MAX_TOKENS=4096
+GROUND_TRUTH_TRANSLATION_MAX_TOKENS=256
+REQUEST_TIMEOUT=7200

--- a/examples/inference/configs/dispatcher-worker-translation-split-traces.conf
+++ b/examples/inference/configs/dispatcher-worker-translation-split-traces.conf
@@ -1,0 +1,14 @@
+SERVER_ADDRESS_FILE=.dispatcher-server-translation-split-traces
+DISPATCHER_PKG=/shared_silo/scratch/adamhrin@amd.com/dispatcher_inference
+SKIP_DISPATCHER_INSTALL=1
+LAUNCHER=/shared_silo/scratch/adamhrin@amd.com/dispatcher_inference/examples/inference/tw_singularity_launcher.sh
+TASK=tasks.reasoning_translation_split_traces_task.ReasoningTranslationSplitTracesTask
+LANGUAGE=fi
+MODEL=/shared_silo/scratch/models/gemma-4-31B-it
+GPUS_PER_TASK=1
+WORKERS=128
+MAX_MODEL_LEN=32768
+PROMPT_TRANSLATION_MAX_TOKENS=4096
+TRACE_TRANSLATION_MAX_TOKENS=16384
+ANSWER_TRANSLATION_MAX_TOKENS=4096
+REQUEST_TIMEOUT=7200

--- a/examples/inference/configs/dispatcher-workers-annotations.conf
+++ b/examples/inference/configs/dispatcher-workers-annotations.conf
@@ -1,0 +1,7 @@
+SERVER_ADDRESS_FILE=.dispatcher-server-annotations
+DISPATCHER_PKG=/shared_silo/scratch/adamhrin@amd.com/dispatcher_inference
+LAUNCHER=/shared_silo/scratch/adamhrin@amd.com/dispatcher_inference/examples/inference/tw_singularity_launcher.sh
+TASK=tasks.inference_task.InferenceTask
+REQUEST_TIMEOUT=120
+MAX_MODEL_LEN=32768
+GPUS_PER_TASK=1

--- a/examples/inference/configs/dispatcher-workers-sft-pipeline-stage5.conf
+++ b/examples/inference/configs/dispatcher-workers-sft-pipeline-stage5.conf
@@ -1,0 +1,10 @@
+SERVER_ADDRESS_FILE=.dispatcher-server-sft-pipeline-stage5
+DISPATCHER_PKG=/shared_silo/scratch/adamhrin@amd.com/dispatcher_inference
+LAUNCHER=/shared_silo/scratch/adamhrin@amd.com/dispatcher_inference/examples/inference/tw_singularity_launcher.sh
+TASK=tasks.inference_task_think.InferenceTask
+MODEL=/shared_silo/scratch/models/gemma-4-31B-it
+REQUEST_TIMEOUT=5000
+STARTUP_TIMEOUT=20000
+MAX_MODEL_LEN=65536
+GPUS_PER_TASK=1
+WORKERS=128

--- a/examples/inference/configs/dispatcher-workers-translation.conf
+++ b/examples/inference/configs/dispatcher-workers-translation.conf
@@ -1,0 +1,8 @@
+SERVER_ADDRESS_FILE=.dispatcher-server-translation
+DISPATCHER_PKG=/shared_silo/scratch/adamhrin@amd.com/dispatcher_inference
+LAUNCHER=/shared_silo/scratch/adamhrin@amd.com/dispatcher_inference/examples/inference/tw_singularity_launcher.sh
+TASK=tasks.reasoning_translation_task.ReasoningTranslationTask
+LANGUAGE=fi
+MODEL=/shared_silo/scratch/models/gemma-4-31B-it
+GPUS_PER_TASK=1
+WORKERS=128

--- a/examples/inference/jobs/launch_dispatcher_server.sh
+++ b/examples/inference/jobs/launch_dispatcher_server.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#SBATCH --job-name=dispatcher-server
+#SBATCH --partition=amd-tw-verification
+#SBATCH --gpus=0
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=64G
+#SBATCH --time=10-00:00:00
+#SBATCH --output=logs/dispatcher-server-%j.out
+#SBATCH --error=logs/dispatcher-server-%j.err
+
+set -euo pipefail
+loginctl enable-linger "$(id -un)" 2>/dev/null || true
+CONFIG_FILE="${1:-configs/dispatcher-server-sft-pipeline-stage5.conf}"
+cd "$SLURM_SUBMIT_DIR"
+exec ./start_dispatcher_server.sh "$CONFIG_FILE" --run-server

--- a/examples/inference/jobs/launch_dispatcher_worker.sh
+++ b/examples/inference/jobs/launch_dispatcher_worker.sh
@@ -1,0 +1,231 @@
+#!/bin/bash
+###############################################################################
+# launch_annotation_workers.sh - Single-node preemptable dispatcher worker
+#
+# Runs one dispatcher worker against the central
+# dispatcher server launched by start_dispatcher_server.sh.
+#
+# When preempted, any in-flight work items time out on the server side and are
+# automatically reissued to another (or the same requeued) worker. No data is lost.
+#
+# Usage:
+# sbatch jobs/launch_translation_workers.sh [configs/your-config.conf]
+#
+# If a config file is provided, it is sourced before applying defaults.
+# Config files are shell-sourceable files with KEY=VALUE pairs.
+###############################################################################
+
+#SBATCH --job-name=inference
+#SBATCH --partition=amd-tw-verification
+#SBATCH --time=10-00:00:00
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=1
+#SBATCH --mem=112G
+#SBATCH --cpus-per-task=7
+#SBATCH --hint=nomultithread
+#SBATCH --output=logs/%A_%a.out
+#SBATCH --error=logs/%A_%a.err
+#SBATCH --open-mode=append
+
+set -euo pipefail
+
+###############################################################################
+# Config file: source if provided as first argument
+###############################################################################
+
+CONFIG_FILE="${1:-}"
+
+# Resolve working directory (reasoning_traces/)
+WORK_DIR="${WORK_DIR:-$SLURM_SUBMIT_DIR}"
+
+if [ -n "$CONFIG_FILE" ]; then
+  if [[ "$CONFIG_FILE" != /* ]]; then
+    CONFIG_FILE="$(cd "$(dirname "$CONFIG_FILE")" && pwd)/$(basename "$CONFIG_FILE")"
+  fi
+  if [ ! -f "$CONFIG_FILE" ]; then
+    echo "ERROR: Config file not found: $CONFIG_FILE" >&2
+    exit 1
+  fi
+  source "$CONFIG_FILE"
+fi
+
+###############################################################################
+# Configuration - defaults for anything not set by config file or environment
+###############################################################################
+
+LAUNCHER="${LAUNCHER:-$WORK_DIR/singularity_launcher.sh}"
+SERVER_ADDRESS_FILE="${SERVER_ADDRESS_FILE:-.dispatcher-server}"
+ADDRESS_FILE="$WORK_DIR/$SERVER_ADDRESS_FILE"
+
+# Dispatcher package source (mirrors start_dispatcher_server.sh)
+DISPATCHER_PKG="${DISPATCHER_PKG:-/shared_silo/scratch/adamhrin@amd.com/dispatcher}"
+
+# Skip pip install when dispatcher is already installed (avoids race conditions when
+# multiple workers share the same user site-packages). Set SKIP_DISPATCHER_INSTALL=1
+# to use pre-installed dispatcher (e.g. from a one-time setup job).
+SKIP_DISPATCHER_INSTALL="${SKIP_DISPATCHER_INSTALL:-1}"
+
+TASK=${TASK:-tasks.task.Task}
+
+MODEL=${MODEL:-Qwen/Qwen3-30B-A3B-Instruct-2507}
+GPUS_PER_TASK=${GPUS_PER_TASK:-8}
+LANGUAGE=${LANGUAGE:-}
+PROMPT_TRANSLATION_MAX_TOKENS=${PROMPT_TRANSLATION_MAX_TOKENS:-}
+TRACE_TRANSLATION_MAX_TOKENS=${TRACE_TRANSLATION_MAX_TOKENS:-}
+ANSWER_TRANSLATION_MAX_TOKENS=${ANSWER_TRANSLATION_MAX_TOKENS:-}
+GROUND_TRUTH_TRANSLATION_MAX_TOKENS=${GROUND_TRUTH_TRANSLATION_MAX_TOKENS:-}
+HIP_VISIBLE_DEVICES=${HIP_VISIBLE_DEVICES:-$(seq -s, 0 $((GPUS_PER_TASK - 1)))}
+VLLM_EXTRA_ARGS=${VLLM_EXTRA_ARGS:-}
+
+WORKERS=${WORKERS:-256}
+BATCH_SIZE=${BATCH_SIZE:-1}
+
+REQUEST_TIMEOUT=${REQUEST_TIMEOUT:-3600}
+STARTUP_TIMEOUT=${STARTUP_TIMEOUT:-7200}
+
+MAX_MODEL_LEN=${MAX_MODEL_LEN:-65536}
+
+###############################################################################
+# Resolve dispatcher server address
+###############################################################################
+
+if [ -z "${DISPATCHER_SERVER:-}" ] || [ -z "${DISPATCHER_PORT:-}" ]; then
+  if [ -f "$ADDRESS_FILE" ]; then
+    IFS=: read -r DISPATCHER_SERVER DISPATCHER_PORT < "$ADDRESS_FILE"
+    echo "Read dispatcher address from $ADDRESS_FILE: $DISPATCHER_SERVER:$DISPATCHER_PORT"
+  else
+    echo "ERROR: No dispatcher address found."
+    echo "Either set DISPATCHER_SERVER and DISPATCHER_PORT env vars,"
+    echo "or run start_dispatcher_server.sh first."
+    exit 1
+  fi
+fi
+
+export DISPATCHER_SERVER
+export DISPATCHER_PORT
+
+###############################################################################
+# Set up working directory and source launcher
+###############################################################################
+
+cd "$WORK_DIR"
+source "$LAUNCHER"
+
+###############################################################################
+# Wait for dispatcher server to be reachable
+###############################################################################
+
+echo "Connecting to dispatcher server at $DISPATCHER_SERVER:$DISPATCHER_PORT..."
+for i in $(seq 1 120); do
+  curl -sf -o /dev/null --max-time 2 "http://$DISPATCHER_SERVER:$DISPATCHER_PORT/status" && break || true
+  sleep 1
+done
+curl -sf -o /dev/null --max-time 2 "http://$DISPATCHER_SERVER:$DISPATCHER_PORT/status" || {
+  echo "[ERROR] Dispatcher server not reachable at $DISPATCHER_SERVER:$DISPATCHER_PORT"
+  exit 1
+}
+echo "Server is reachable."
+
+###############################################################################
+# Install dispatcher package in container (or skip if already installed)
+# When multiple workers run in parallel, they share the same user site-packages.
+# Concurrent pip install/uninstall causes race conditions (ModuleNotFoundError).
+# Use flock to serialize installs, or set SKIP_DISPATCHER_INSTALL=1 to skip.
+###############################################################################
+
+if [ "$SKIP_DISPATCHER_INSTALL" = "1" ]; then
+  echo "Skipping dispatcher install (SKIP_DISPATCHER_INSTALL=1). Adding $DISPATCHER_PKG to PYTHONPATH."
+  DISPATCHER_PYTHONPATH_EXTRA="$DISPATCHER_PKG"
+else
+  INSTALL_LOCK="$WORK_DIR/.dispatcher_install.lock"
+  echo "Installing dispatcher package from $DISPATCHER_PKG (lock: $INSTALL_LOCK)..."
+  (
+    flock -x -w 300 9 || { echo "[ERROR] Failed to acquire install lock"; exit 1; }
+    run_sing_python -m pip install --user -e "$DISPATCHER_PKG"
+  ) 9>"$INSTALL_LOCK"
+  echo "Dispatcher install complete."
+  DISPATCHER_PYTHONPATH_EXTRA=""
+fi
+
+###############################################################################
+# Derive vLLM / MASTER ports from the physical GPU ID assigned by SLURM.
+###############################################################################
+
+GPU_ID="${SLURM_JOB_GPUS%%,*}"
+if [ -z "$GPU_ID" ]; then
+  echo "[ERROR] SLURM_JOB_GPUS is empty; cannot derive a deterministic port." >&2
+  exit 1
+fi
+
+VLLM_PORT=$((20000 + GPU_ID * 100))
+MASTER_PORT=$((19000 + GPU_ID * 100))
+
+if [ -n "$(ss -Hltn "sport = :$VLLM_PORT" 2>/dev/null)" ]; then
+  echo "[ERROR] Port $VLLM_PORT already in use on $(hostname); refusing to start." >&2
+  exit 1
+fi
+
+###############################################################################
+# Run worker in container
+#
+# Signal handling for preemption:
+# Singularity tears down the container (including network) when it receives
+# SIGTERM directly, which prevents the Python signal handler from POST-ing
+# /release.  We use job control (set -m) to run the worker in its own process
+# group so SLURM's SIGTERM only hits the outer bash.  The trap forwards SIGTERM
+# to the worker process group, and the inner bash ignores it so only Python
+# handles the signal while the container is still alive.
+###############################################################################
+
+_CHILD_PID=
+trap '[ -n "$_CHILD_PID" ] && { kill -TERM -- -"$_CHILD_PID" 2>/dev/null; wait "$_CHILD_PID" 2>/dev/null; }' TERM INT
+
+set -m
+run_sing_bash "
+  set -uo pipefail
+  trap : TERM HUP
+  DISPATCHER_PYTHONPATH_EXTRA=\"$DISPATCHER_PYTHONPATH_EXTRA\"
+  if [ -n \"\$DISPATCHER_PYTHONPATH_EXTRA\" ]; then
+    export PYTHONPATH=\"\$DISPATCHER_PYTHONPATH_EXTRA\":\${PYTHONPATH:-}
+  fi
+
+  export HIP_VISIBLE_DEVICES=\"$HIP_VISIBLE_DEVICES\"
+  export LANGUAGE=\"$LANGUAGE\"
+  export MODEL=\"$MODEL\"
+  [ -n \"$PROMPT_TRANSLATION_MAX_TOKENS\" ] && export PROMPT_TRANSLATION_MAX_TOKENS=\"$PROMPT_TRANSLATION_MAX_TOKENS\"
+  [ -n \"$TRACE_TRANSLATION_MAX_TOKENS\" ] && export TRACE_TRANSLATION_MAX_TOKENS=\"$TRACE_TRANSLATION_MAX_TOKENS\"
+  [ -n \"$ANSWER_TRANSLATION_MAX_TOKENS\" ] && export ANSWER_TRANSLATION_MAX_TOKENS=\"$ANSWER_TRANSLATION_MAX_TOKENS\"
+  [ -n \"$GROUND_TRUTH_TRANSLATION_MAX_TOKENS\" ] && export GROUND_TRUTH_TRANSLATION_MAX_TOKENS=\"$GROUND_TRUTH_TRANSLATION_MAX_TOKENS\"
+  VLLM_EXTRA_ARGS=\"$VLLM_EXTRA_ARGS\"
+
+  export MASTER_ADDR=\${MASTER_ADDR:-127.0.0.1}
+  export MASTER_PORT=$MASTER_PORT
+  export VLLM_PORT=$VLLM_PORT
+
+  VLLM_ARGS=()
+  if [ -n \"\$VLLM_EXTRA_ARGS\" ]; then
+    VLLM_ARGS=(--vllm-extra-args \"\$VLLM_EXTRA_ARGS\")
+  fi
+
+  echo \"Launching worker on \$(hostname) with GPUs \$HIP_VISIBLE_DEVICES (job \${SLURM_JOB_ID:-unknown})\"
+
+  run_python -m dispatcher.taskmanager.cli \
+    --dispatcher $DISPATCHER_SERVER:$DISPATCHER_PORT \
+    --task $TASK \
+    --batch-size $BATCH_SIZE \
+    --workers $WORKERS \
+    --max-model-len $MAX_MODEL_LEN \
+    --tensor-parallel $GPUS_PER_TASK \
+    --model $MODEL \
+    --port \$VLLM_PORT \
+    --request-timeout $REQUEST_TIMEOUT \
+    --startup-timeout $STARTUP_TIMEOUT \
+    \"\${VLLM_ARGS[@]}\" " &
+
+_CHILD_PID=$!
+# Double-wait idiom: when a signal interrupts the first wait, it returns
+# 128+signum (not the child's real status) and the trap fires.  The second
+# wait then retrieves the child's actual exit status from bash's cache.
+wait "$_CHILD_PID" 2>/dev/null
+wait "$_CHILD_PID" 2>/dev/null

--- a/examples/inference/jobs/pull_vllm_sif.sh
+++ b/examples/inference/jobs/pull_vllm_sif.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#SBATCH --job-name=pull_vllm_sif
+#SBATCH --partition=amd-tw-verification
+#SBATCH --gpus-per-node=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=64G
+#SBATCH --time=2:00:00
+#SBATCH --output=logs/pull_%j.out
+#SBATCH --error=logs/pull_%j.err
+
+set -euo pipefail
+
+TAG="nightly_main_20260514"
+DATESTAMP="20260515"
+OUT_NAME="vllm-dev_${TAG}_${DATESTAMP}.sif"
+DEST_DIR="/shared_silo/scratch/containers"
+FALLBACK_DIR="/shared_silo/scratch/adamhrin@amd.com/containers"
+
+# Pick singularity or apptainer
+if command -v singularity >/dev/null 2>&1; then
+    SING=singularity
+elif command -v apptainer >/dev/null 2>&1; then
+    SING=apptainer
+else
+    echo "ERROR: neither singularity nor apptainer on PATH" >&2
+    module avail 2>&1 | head -50 >&2 || true
+    exit 1
+fi
+echo "Using container runtime: $SING ($($SING --version))"
+
+# Choose output directory
+if touch "${DEST_DIR}/.write_test_${SLURM_JOB_ID}" 2>/dev/null; then
+    rm -f "${DEST_DIR}/.write_test_${SLURM_JOB_ID}"
+    OUT_DIR="${DEST_DIR}"
+else
+    echo "WARN: ${DEST_DIR} not writable; falling back to ${FALLBACK_DIR}"
+    mkdir -p "${FALLBACK_DIR}"
+    OUT_DIR="${FALLBACK_DIR}"
+fi
+
+OUT_PATH="${OUT_DIR}/${OUT_NAME}"
+echo "Output will be: ${OUT_PATH}"
+
+# tmp dirs (image layers can be huge — use node-local /tmp)
+export SINGULARITY_TMPDIR="/tmp/${USER}/${SLURM_JOB_ID}"
+export APPTAINER_TMPDIR="${SINGULARITY_TMPDIR}"
+export SINGULARITY_CACHEDIR="${SINGULARITY_TMPDIR}/cache"
+export APPTAINER_CACHEDIR="${SINGULARITY_CACHEDIR}"
+mkdir -p "${SINGULARITY_TMPDIR}" "${SINGULARITY_CACHEDIR}"
+
+cd "${OUT_DIR}"
+echo "Pulling docker://rocm/vllm-dev:${TAG} -> ${OUT_PATH}"
+time "${SING}" build "${OUT_NAME}" "docker://rocm/vllm-dev:${TAG}"
+
+echo "Done. Final size:"
+ls -lh "${OUT_PATH}"
+
+# cleanup tmp
+rm -rf "${SINGULARITY_TMPDIR}" || true

--- a/examples/inference/start_dispatcher_server.sh
+++ b/examples/inference/start_dispatcher_server.sh
@@ -1,0 +1,226 @@
+#!/bin/bash
+###############################################################################
+# start_dispatcher_server.sh - Launch dispatcher server on the login node in tmux
+#
+# Usage:
+#   ./start_dispatcher_server.sh [config]          # Start server
+#   ./start_dispatcher_server.sh [config] --stop   # Stop the server
+#   ./start_dispatcher_server.sh [config] --status # Check server status
+#
+# If a config file is provided, it is sourced before applying defaults.
+# Config files are shell-sourceable files with KEY=VALUE pairs.
+# See configs/dispatcher-server.conf.example for available options.
+#
+# The server address is saved to .dispatcher_address_<SESSION_NAME>
+# for the worker scripts. Server stdout/stderr are logged to
+# logs/<SESSION_NAME>.{out,err}.
+# The server is lightweight (FastAPI) and safe to run on the login node.
+###############################################################################
+
+set -euo pipefail
+
+###############################################################################
+# Argument parsing: [config_file] [--stop|--status|--run-server]
+###############################################################################
+
+CONFIG_FILE=""
+ACTION=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --stop|--status|--run-server) ACTION="$arg" ;;
+    *) CONFIG_FILE="$arg" ;;
+  esac
+done
+
+# Resolve working directory (reasoning_traces/)
+WORK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source config file if provided
+if [ -n "$CONFIG_FILE" ]; then
+  if [[ "$CONFIG_FILE" != /* ]]; then
+    CONFIG_FILE="$(cd "$(dirname "$CONFIG_FILE")" && pwd)/$(basename "$CONFIG_FILE")"
+  fi
+  if [ ! -f "$CONFIG_FILE" ]; then
+    echo "ERROR: Config file not found: $CONFIG_FILE" >&2
+    exit 1
+  fi
+  source "$CONFIG_FILE"
+fi
+
+###############################################################################
+# Configuration - defaults for anything not set by config file or environment
+###############################################################################
+
+INPUT_FILE=${INPUT_FILE:-/shared_silo/scratch/adamhrin@amd.com/dispatcher/examples/reasoning_traces/data/Llama-Nemotron-SFT-math.jsonl}
+OUTPUT_FILE=${OUTPUT_FILE:-/shared_silo/scratch/adamhrin@amd.com/dispatcher/examples/reasoning_traces/data/Llama-Nemotron-SFT-math_translated_DeepSeek-V3_fi.jsonl}
+
+WORK_TIMEOUT=${WORK_TIMEOUT:-1800}
+DISPATCHER_PORT=${DISPATCHER_PORT:-9999}
+MAX_RETRIES=${MAX_RETRIES:-3}
+SESSION_NAME=${SESSION_NAME:-"dispatcher-server"}
+
+# Dispatcher package source
+DISPATCHER_PKG=${DISPATCHER_PKG:-/shared_silo/scratch/adamhrin@amd.com/dispatcher}
+SKIP_DISPATCHER_INSTALL=${SKIP_DISPATCHER_INSTALL:-0}
+
+# Per-session file paths (avoids collisions between concurrent instances)
+ADDRESS_FILE="$WORK_DIR/.${SESSION_NAME}"
+LOG_OUT="$WORK_DIR/logs/${SESSION_NAME}.out"
+LOG_ERR="$WORK_DIR/logs/${SESSION_NAME}.err"
+
+# Build the command prefix for helper messages
+SELF_CMD="$0"
+[ -n "$CONFIG_FILE" ] && SELF_CMD="$0 $CONFIG_FILE"
+
+###############################################################################
+# --stop: kill the tmux session and clean up
+###############################################################################
+if [ "$ACTION" = "--stop" ]; then
+  if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+    tmux kill-session -t "$SESSION_NAME"
+    echo "Server session '$SESSION_NAME' stopped."
+  else
+    echo "No active session '$SESSION_NAME' found."
+  fi
+  rm -f "$ADDRESS_FILE"
+  exit 0
+fi
+
+###############################################################################
+# --status: check the server
+###############################################################################
+if [ "$ACTION" = "--status" ]; then
+  if [ -f "$ADDRESS_FILE" ]; then
+    ADDR=$(cat "$ADDRESS_FILE")
+    echo "Address file: $ADDR"
+    echo "Querying server..."
+    curl -s "http://$ADDR/status" 2>/dev/null && echo "" || echo "Server not reachable."
+  else
+    echo "No address file found. Server may not be running."
+  fi
+  if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+    echo "Tmux session '$SESSION_NAME' is active."
+  else
+    echo "Tmux session '$SESSION_NAME' not found."
+  fi
+  echo ""
+  echo "Log files:"
+  echo "  stdout: $LOG_OUT"
+  echo "  stderr: $LOG_ERR"
+  exit 0
+fi
+
+###############################################################################
+# --run-server: internal entry point (called inside the tmux session)
+###############################################################################
+if [ "$ACTION" = "--run-server" ]; then
+  cd "$WORK_DIR"
+  mkdir -p "$WORK_DIR/logs"
+
+  # Log all output to files while also showing in the tmux terminal
+  exec > >(tee -a "$LOG_OUT") 2> >(tee -a "$LOG_ERR" >&2)
+
+  export DISPATCHER_SERVER=$(hostname)
+  export DISPATCHER_PORT
+
+  # Write address file early so workers can discover us.
+  # The main script waits for the TCP port to actually open before declaring
+  # success, so this is safe even though the server isn't listening yet.
+  echo "${DISPATCHER_SERVER}:${DISPATCHER_PORT}" > "$ADDRESS_FILE"
+
+  if [ "$SKIP_DISPATCHER_INSTALL" = "1" ]; then
+    echo "Skipping dispatcher install (SKIP_DISPATCHER_INSTALL=1). Adding $DISPATCHER_PKG to PYTHONPATH."
+    export PYTHONPATH="$DISPATCHER_PKG:${PYTHONPATH:-}"
+  else
+    # Install dispatcher package in user site-packages (no singularity on login node).
+    echo "Installing dispatcher package from $DISPATCHER_PKG..."
+    pip install --user -e "$DISPATCHER_PKG"
+  fi
+
+  echo "=========================================="
+  echo "Dispatcher server starting"
+  echo "  Session:      $SESSION_NAME"
+  echo "  Config:       ${CONFIG_FILE:-<defaults>}"
+  echo "  Address:      $DISPATCHER_SERVER:$DISPATCHER_PORT"
+  echo "  Input:        $INPUT_FILE"
+  echo "  Output:       $OUTPUT_FILE"
+  echo "  Work timeout: $WORK_TIMEOUT"
+  echo "  Max retries:  $MAX_RETRIES"
+  echo "  Log stdout:   $LOG_OUT"
+  echo "  Log stderr:   $LOG_ERR"
+  echo "=========================================="
+
+  until python3 -m dispatcher.server \
+    --infile "$INPUT_FILE" \
+    --outfile "$OUTPUT_FILE" \
+    --work-timeout "$WORK_TIMEOUT" \
+    --max-retries "$MAX_RETRIES" \
+    --host 0.0.0.0 \
+    --port "$DISPATCHER_PORT"; do
+    echo "Dispatcher exited non-zero; restarting in 5s (checkpoint will be resumed)."
+    sleep 5
+  done
+
+  echo "Dispatcher exited normally (all work complete)."
+  rm -f "$ADDRESS_FILE"
+  exit 0
+fi
+
+###############################################################################
+# Main: start the server in a new tmux session
+###############################################################################
+if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+  echo "Tmux session '$SESSION_NAME' already exists."
+  echo "  Attach:  tmux attach -t $SESSION_NAME"
+  echo "  Stop:    $SELF_CMD --stop"
+  echo "  Status:  $SELF_CMD --status"
+  exit 1
+fi
+
+echo "Starting dispatcher server in tmux session '$SESSION_NAME'..."
+
+# Pass the config file into the tmux session so --run-server can source it.
+# The config is a file on disk, so no env-var propagation issues.
+CONFIG_ARG=""
+[ -n "$CONFIG_FILE" ] && CONFIG_ARG="'$CONFIG_FILE'"
+tmux new-session -d -s "$SESSION_NAME" "bash --login $0 $CONFIG_ARG --run-server"
+
+# Stream server logs in the background so the user sees progress.
+mkdir -p "$WORK_DIR/logs"
+touch "$LOG_OUT"
+tail -f "$LOG_OUT" &
+TAIL_PID=$!
+cleanup_tail() { kill "$TAIL_PID" 2>/dev/null; wait "$TAIL_PID" 2>/dev/null; }
+trap cleanup_tail EXIT
+
+# Wait for the TCP port to actually open (not just the address file).
+echo "Waiting for server to come up (this may take a few minutes on first run)..."
+for i in $(seq 1 150); do
+  if [ -f "$ADDRESS_FILE" ]; then
+    ADDR=$(cat "$ADDRESS_FILE")
+    IFS=: read -r HOST PORT <<< "$ADDR"
+    if curl -sf -o /dev/null --max-time 2 "http://$HOST:$PORT/status"; then
+      cleanup_tail
+      trap - EXIT
+      echo ""
+      echo "Server is up at: $ADDR"
+      echo ""
+      echo "  Monitor: tmux attach -t $SESSION_NAME"
+      echo "  Logs:    tail -f $LOG_OUT"
+      echo "  Status:  $SELF_CMD --status"
+      echo "  Stop:    $SELF_CMD --stop"
+      echo "  Check:   curl http://$ADDR/status"
+      exit 0
+    fi
+  fi
+  sleep 2
+done
+
+cleanup_tail
+trap - EXIT
+echo ""
+echo "WARNING: Server did not become reachable within timeout."
+echo "Check the tmux session: tmux attach -t $SESSION_NAME"
+echo "Check logs: $LOG_ERR"
+exit 1

--- a/examples/inference/tasks/inference_task.py
+++ b/examples/inference/tasks/inference_task.py
@@ -1,0 +1,70 @@
+"""
+Task description: Translates reasoning traces line-by-line from generated reasoning answers.
+"""
+from typing import Any, Dict, Generator, List, Union
+from functools import lru_cache
+
+from dispatcher.taskmanager.backend.request import Request, Response
+from dispatcher.taskmanager.task.base import GeneratorTask
+from dispatcher.taskmanager.task import TaskFailed, TaskRetry
+
+import os
+import logging
+import re
+
+__all__ = ["InferenceTask"]
+
+class InferenceTask(GeneratorTask):
+    """Simple inference task"""
+
+    GEN_PARAMS: Dict[str, Any] = {
+        "temperature": 0.7,
+        "top_p": 0.95,
+        "max_tokens": 1024,
+    }
+
+    logger = logging.getLogger(__name__)
+    
+    # --------------- generator ---------------
+    def task_generator(self) -> Generator[Union[Request, List[Request]], Any, Dict[str, Any]]:
+        # self.data is prepopulated with the data from the jsonl row being processed
+        # Get the generated reasoning answer
+        self.logger.info(f"[InferenceTask] ID:{self.data.get('prompt_id')} Processing sample")
+        input_messages = self.data.get("messages", [])
+
+        resp: Response = yield Request({"messages": input_messages, **self.GEN_PARAMS})
+       
+        if not resp.is_success:
+            self.logger.error(
+                "[InferenceTask] ID:%s Backend request failed: %s",
+                self.data.get("prompt_id"),
+                resp.error,
+            )
+            raise TaskFailed(
+                message=f"Backend request failed: {resp.error}",
+                error_type="response_generation_error",
+            )
+
+        response_text = resp.get_text()
+        if response_text is None:
+            self.logger.error(
+                "[InferenceTask] ID:%s Backend response had no extractable text payload",
+                self.data.get("prompt_id"),
+            )
+            raise TaskFailed(
+                message="Backend response had no extractable text payload",
+                error_type="response_parsing_error",
+            )
+
+        response = response_text.strip()
+
+        self.logger.info(
+            f"[InferenceTask] ID:{self.data.get('prompt_id')} Finished processing sample"
+        )
+
+        output_messages = list(input_messages) + [{"role": "assistant", "content": response}]
+        # build_result spreads self.data, sets success=True, then merges payload.
+        return self.build_result(
+            response=response,
+            output_messages=output_messages,
+        )

--- a/examples/inference/tasks/inference_task_think.py
+++ b/examples/inference/tasks/inference_task_think.py
@@ -1,0 +1,74 @@
+"""
+Task description: Translates reasoning traces line-by-line from generated reasoning answers.
+"""
+from typing import Any, Dict, Generator, List, Union
+from functools import lru_cache
+
+from dispatcher.taskmanager.backend.request import Request, Response
+from dispatcher.taskmanager.task.base import GeneratorTask
+from dispatcher.taskmanager.task import TaskFailed, TaskRetry
+
+import os
+import logging
+import re
+
+__all__ = ["InferenceTask"]
+
+class InferenceTask(GeneratorTask):
+    """Simple inference task"""
+
+    GEN_PARAMS: Dict[str, Any] = {
+        "temperature": 0.8,
+        "top_p": 0.95,
+        "max_tokens": 32768,
+    	"extra_body": {
+        	"chat_template_kwargs": {"enable_thinking": True},
+        	"skip_special_tokens": False
+    	}
+    }
+
+    logger = logging.getLogger(__name__)
+    
+    # --------------- generator ---------------
+    def task_generator(self) -> Generator[Union[Request, List[Request]], Any, Dict[str, Any]]:
+        # self.data is prepopulated with the data from the jsonl row being processed
+        # Get the generated reasoning answer
+        self.logger.info(f"[InferenceTask] ID:{self.data.get('prompt_id')} Processing sample")
+        input_messages = self.data.get("messages", [])
+
+        resp: Response = yield Request({"messages": input_messages, **self.GEN_PARAMS})
+       
+        if not resp.is_success:
+            self.logger.error(
+                "[InferenceTask] ID:%s Backend request failed: %s",
+                self.data.get("prompt_id"),
+                resp.error,
+            )
+            raise TaskFailed(
+                message=f"Backend request failed: {resp.error}",
+                error_type="response_generation_error",
+            )
+
+        response_text = resp.get_text()
+        if response_text is None:
+            self.logger.error(
+                "[InferenceTask] ID:%s Backend response had no extractable text payload",
+                self.data.get("prompt_id"),
+            )
+            raise TaskFailed(
+                message="Backend response had no extractable text payload",
+                error_type="response_parsing_error",
+            )
+
+        response = response_text.strip()
+
+        self.logger.info(
+            f"[InferenceTask] ID:{self.data.get('prompt_id')} Finished processing sample"
+        )
+
+        output_messages = list(input_messages) + [{"role": "assistant", "content": response}]
+        # build_result spreads self.data, sets success=True, then merges payload.
+        return self.build_result(
+            response=response,
+            output_messages=output_messages,
+        )

--- a/examples/inference/tasks/prompt_translation_task.py
+++ b/examples/inference/tasks/prompt_translation_task.py
@@ -1,0 +1,280 @@
+"""
+Task description: Translates prompt and ground_truth fields from JSONL records.
+"""
+from typing import Any, Dict, Generator, List, Union
+
+from dispatcher.taskmanager.backend.request import Request, Response
+from dispatcher.taskmanager.task.base import GeneratorTask
+from dispatcher.taskmanager.task import TaskRetry
+
+import logging
+import os
+import uuid
+
+__all__ = ["PromptTranslationTask"]
+
+LANGUAGE = os.environ.get("LANGUAGE")
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    return int(value) if value else default
+
+
+PROMPT_TRANSLATION_MAX_TOKENS = _env_int("PROMPT_TRANSLATION_MAX_TOKENS", 4096)
+GROUND_TRUTH_TRANSLATION_MAX_TOKENS = _env_int(
+    "GROUND_TRUTH_TRANSLATION_MAX_TOKENS",
+    _env_int("ANSWER_TRANSLATION_MAX_TOKENS", 1024),
+)
+
+LANGUAGE_NAMES = {
+    "bg": ["Bulgarian", "bul"],
+    "cs": ["Czech", "ces"],
+    "da": ["Danish", "dan"],
+    "de": ["German", "deu"],
+    "el": ["Greek", "ell"],
+    "en": ["English", "eng"],
+    "es": ["Spanish", "spa"],
+    "et": ["Estonian", "est"],
+    "fi": ["Finnish", "fin"],
+    "fr": ["French", "fra"],
+    "ga": ["Irish", "gle"],
+    "hr": ["Croatian", "hrv"],
+    "hu": ["Hungarian", "hun"],
+    "it": ["Italian", "ita"],
+    "lt": ["Lithuanian", "lit"],
+    "lv": ["Latvian", "lav"],
+    "mt": ["Maltese", "mlt"],
+    "nl": ["Dutch", "nld"],
+    "pl": ["Polish", "pol"],
+    "pt": ["Portuguese", "por"],
+    "ro": ["Romanian", "ron"],
+    "sk": ["Slovak", "slk"],
+    "sl": ["Slovenian", "slv"],
+    "sv": ["Swedish", "swe"],
+    "is": ["Icelandic", "isl"],
+    "no": ["Norwegian", "nob"],
+}
+
+TRANSLATION_PROMPT = """
+You are a professional translator specializing in mathematics and scientific texts. Your task is to translate the following content faithfully and accurately into {language}.
+
+Guidelines:
+
+1. Preserve all LaTeX code, equations, symbols, and formatting exactly as written.
+2. Translate only the surrounding natural language, not the math expressions inside \( ... \), \[ ... \], or $$ ... $$.
+3. Maintain the precise meaning, tone, and logical structure of the original text.
+4. Use the standard mathematical terminology of the target language.
+5. Do not simplify, interpret, solve, or expand the math; your goal is linguistic translation only.
+6. Keep variable names, constants, notation, numeric answers, and short answer labels unchanged when translation is not needed.
+7. Do not explain your translation; output only the translated text.
+
+Text to translate:
+{text}
+"""
+
+
+class PromptTranslationTask(GeneratorTask):
+    """Translation of Dolci prompt and ground_truth fields."""
+
+    PROMPT_TRANSLATION_GEN_PARAMS: Dict[str, Any] = {
+        "temperature": 0.7,
+        "top_p": 0.95,
+        "max_tokens": PROMPT_TRANSLATION_MAX_TOKENS,
+    }
+
+    GROUND_TRUTH_TRANSLATION_GEN_PARAMS: Dict[str, Any] = {
+        "temperature": 0.7,
+        "top_p": 0.95,
+        "max_tokens": GROUND_TRUTH_TRANSLATION_MAX_TOKENS,
+    }
+
+    logger = logging.getLogger(__name__)
+
+    def _failed_result(self, *, error_type: str, message: str, **payload: Any) -> Dict[str, Any]:
+        """Wrap Task.build_result so every failure call site logs uniformly."""
+        self.logger.warning(
+            "[PromptTranslationTask] ID:%s Dumping unsuccessful record after final retry: %s",
+            self.data.get("id"),
+            message,
+        )
+        return self.build_result(
+            success=False,
+            error=message,
+            error_type=error_type,
+            **payload,
+        )
+
+    @staticmethod
+    def _target_language() -> str:
+        return LANGUAGE_NAMES.get(LANGUAGE, ["Finnish"])[0]
+
+    @classmethod
+    def _messages_for_text(cls, text: str) -> List[Dict[str, str]]:
+        return [
+            {
+                "role": "user",
+                "content": TRANSLATION_PROMPT.format(
+                    language=cls._target_language(),
+                    text=text,
+                ),
+            }
+        ]
+
+    @staticmethod
+    def _normalize_ground_truth(ground_truth: Any) -> tuple[List[str], bool]:
+        if ground_truth is None:
+            return [], True
+        if isinstance(ground_truth, list):
+            return ["" if item is None else str(item) for item in ground_truth], True
+        return [str(ground_truth)], False
+
+    @staticmethod
+    def _restore_ground_truth_shape(translated_items: List[str], was_list: bool) -> Any:
+        if was_list:
+            return translated_items
+        return translated_items[0] if translated_items else ""
+
+    def _response_text_or_retry(
+        self,
+        response: Response,
+        sample_id: str,
+        part: str,
+    ) -> str:
+        if not response.is_success:
+            self.logger.error(
+                "[PromptTranslationTask] ID:%s %s translation request failed: %s",
+                sample_id,
+                part,
+                response.error,
+            )
+            raise TaskRetry(message=f"{part} translation request failed: {response.error}")
+
+        text = response.get_text()
+        if text is None:
+            self.logger.error(
+                "[PromptTranslationTask] ID:%s %s translation response had no extractable text payload",
+                sample_id,
+                part,
+            )
+            raise TaskRetry(
+                message=f"{part} translation response had no extractable text payload"
+            )
+
+        return text.strip()
+
+    # --------------- generator ---------------
+    def task_generator(self) -> Generator[Union[Request, List[Request]], Any, Dict[str, Any]]:
+        sample_id = (
+            self.data.get("id")
+            or self.data.get("custom_id")
+            or self.data.get("prompt_id")
+            or str(uuid.uuid4())
+        )
+        task_uuid = str(uuid.uuid4())
+        # Mutate self.data so build_result spreads the resolved id/task_uuid.
+        self.data["id"] = sample_id
+        self.data["task_uuid"] = task_uuid
+        self.logger.info(
+            "[PromptTranslationTask] ID:%s UUID:%s Processing sample",
+            sample_id,
+            task_uuid,
+        )
+
+        prompt = "" if self.data.get("prompt") is None else str(self.data.get("prompt"))
+        ground_truth_items, ground_truth_was_list = self._normalize_ground_truth(
+            self.data.get("ground_truth")
+        )
+
+        requests = [
+            Request(
+                {
+                    "messages": self._messages_for_text(prompt),
+                    **self.PROMPT_TRANSLATION_GEN_PARAMS,
+                },
+                context={
+                    "task": "prompt_translation",
+                    "sample_id": sample_id,
+                    "task_uuid": task_uuid,
+                    "part": "prompt",
+                },
+            )
+        ]
+        requests.extend(
+            Request(
+                {
+                    "messages": self._messages_for_text(item),
+                    **self.GROUND_TRUTH_TRANSLATION_GEN_PARAMS,
+                },
+                context={
+                    "task": "prompt_translation",
+                    "sample_id": sample_id,
+                    "task_uuid": task_uuid,
+                    "part": "ground_truth",
+                    "index": index,
+                },
+            )
+            for index, item in enumerate(ground_truth_items)
+        )
+
+        responses = yield requests
+        if isinstance(responses, Response):
+            responses = [responses]
+        prompt_response = next(
+            response for response in responses if response.request.context["part"] == "prompt"
+        )
+
+        try:
+            translated_prompt = self._response_text_or_retry(
+                prompt_response,
+                sample_id,
+                "Prompt",
+            )
+        except TaskRetry as exc:
+            if self.is_last_retry_attempt():
+                return self._failed_result(
+                    error_type="prompt_translation_error",
+                    message=str(exc),
+                )
+            raise
+
+        translated_ground_truth_items: List[str] = []
+        ground_truth_responses = sorted(
+            (
+                response
+                for response in responses
+                if response.request.context["part"] == "ground_truth"
+            ),
+            key=lambda response: response.request.context["index"],
+        )
+        for response in ground_truth_responses:
+            try:
+                translated_ground_truth_items.append(
+                    self._response_text_or_retry(
+                        response,
+                        sample_id,
+                        f"Ground truth {response.request.context['index']}",
+                    )
+                )
+            except TaskRetry as exc:
+                if self.is_last_retry_attempt():
+                    return self._failed_result(
+                        error_type="ground_truth_translation_error",
+                        message=str(exc),
+                        translated_prompt=translated_prompt,
+                        translated_ground_truth=translated_ground_truth_items,
+                    )
+                raise
+
+        self.logger.info(
+            "[PromptTranslationTask] ID:%s UUID:%s Finished processing sample",
+            sample_id,
+            task_uuid,
+        )
+        return self.build_result(
+            translated_prompt=translated_prompt,
+            translated_ground_truth=self._restore_ground_truth_shape(
+                translated_ground_truth_items,
+                ground_truth_was_list,
+            ),
+        )

--- a/examples/inference/tasks/reasoning_translation_split_traces_task.py
+++ b/examples/inference/tasks/reasoning_translation_split_traces_task.py
@@ -1,0 +1,392 @@
+"""
+Task description: Translates reasoning traces and final answers separately.
+"""
+from typing import Any, Dict, Generator, List, Union
+from functools import lru_cache
+
+from dispatcher.taskmanager.backend.request import Request, Response
+from dispatcher.taskmanager.task.base import GeneratorTask
+from dispatcher.taskmanager.task import TaskRetry
+
+import os
+import logging
+import re
+import uuid
+
+__all__ = ["ReasoningTranslationSplitTracesTask"]
+
+LANGUAGE = os.environ.get("LANGUAGE")
+MODEL = os.environ.get("MODEL")
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    return int(value) if value else default
+
+
+PROMPT_TRANSLATION_MAX_TOKENS = _env_int("PROMPT_TRANSLATION_MAX_TOKENS", 8192)
+TRACE_TRANSLATION_MAX_TOKENS = _env_int("TRACE_TRANSLATION_MAX_TOKENS", 32768)
+ANSWER_TRANSLATION_MAX_TOKENS = _env_int("ANSWER_TRANSLATION_MAX_TOKENS", 8192)
+THINK_BLOCK_PATTERN = re.compile(r"^\s*<think>(?P<traces>.*?)</think>(?P<answer>.*)\s*$", re.DOTALL)
+
+LANGUAGE_NAMES = {
+    "bg": ["Bulgarian", "bul"],
+    "cs": ["Czech", "ces"],
+    "da": ["Danish", "dan"],
+    "de": ["German", "deu"],
+    "el": ["Greek", "ell"],
+    "en": ["English", "eng"],
+    "es": ["Spanish", "spa"],
+    "et": ["Estonian", "est"],
+    "fi": ["Finnish", "fin"],
+    "fr": ["French", "fra"],
+    "ga": ["Irish", "gle"],
+    "hr": ["Croatian", "hrv"],
+    "hu": ["Hungarian", "hun"],
+    "it": ["Italian", "ita"],
+    "lt": ["Lithuanian", "lit"],
+    "lv": ["Latvian", "lav"],
+    "mt": ["Maltese", "mlt"],
+    "nl": ["Dutch", "nld"],
+    "pl": ["Polish", "pol"],
+    "pt": ["Portuguese", "por"],
+    "ro": ["Romanian", "ron"],
+    "sk": ["Slovak", "slk"],
+    "sl": ["Slovenian", "slv"],
+    "sv": ["Swedish", "swe"],
+    "is": ["Icelandic", "isl"],
+    "no": ["Norwegian", "nob"],
+}
+
+TRANSLATION_PROMPT = """
+You are a professional translator specializing in mathematics and scientific texts. Your task is to translate the following content faithfully and accurately into {language}.
+
+Guidelines:
+
+1. Preserve all LaTeX code, equations, symbols, and formatting exactly as written.
+2. Translate only the surrounding natural language, not the math expressions inside \( ... \), \[ ... \], or $$ ... $$.
+3. Maintain the precise meaning, tone, and logical structure of the original text.
+4. Use the standard mathematical terminology of the target language.
+5. Do not simplify, interpret, or solve the math; your goal is linguistic translation only.
+6. Keep variable names, constants, and notation unchanged.
+7. If an English math term has multiple valid equivalents in the target language, choose the most widely accepted in academic usage.
+8. Do not explain your translation; output only the translated text unless asked otherwise.
+9. Do not add `<think>` or `</think>` tags unless they are present in the input text.
+
+Text to translate:
+{text}
+"""
+
+
+class TranslationIssueType:
+    """Standardized issue types for translation validation."""
+    MISSING_OPEN_THINK_TAG = "missing_open_think_tag"
+    INVALID_OPEN_THINK_TAG_COUNT = "invalid_open_think_tag_count"
+    INVALID_CLOSE_THINK_TAG_COUNT = "invalid_close_think_tag_count"
+    NO_CONTENT_AFTER_CLOSE_THINK_TAG = "no_content_after_close_think_tag"
+    TOKEN_COUNT_DELTA_TOO_LARGE = "token_count_delta_too_large"
+    UNABLE_TO_SPLIT_THINK_BLOCK = "unable_to_split_think_block"
+
+
+class ReasoningTranslationSplitTracesTask(GeneratorTask):
+    """Translation of prompts plus split reasoning trace and answer bodies."""
+
+    PROMPT_TRANSLATION_GEN_PARAMS: Dict[str, Any] = {
+        "temperature": 0.7,
+        "top_p": 0.95,
+        "max_tokens": PROMPT_TRANSLATION_MAX_TOKENS,
+    }
+
+    TRACES_TRANSLATION_GEN_PARAMS: Dict[str, Any] = {
+        "temperature": 0.7,
+        "top_p": 0.95,
+        "max_tokens": TRACE_TRANSLATION_MAX_TOKENS,
+    }
+
+    ANSWER_TRANSLATION_GEN_PARAMS: Dict[str, Any] = {
+        "temperature": 0.7,
+        "top_p": 0.95,
+        "max_tokens": ANSWER_TRANSLATION_MAX_TOKENS,
+    }
+
+    logger = logging.getLogger(__name__)
+
+    def _failed_result(self, *, error_type: str, message: str, **payload: Any) -> Dict[str, Any]:
+        """Wrap Task.build_result so every failure call site logs uniformly."""
+        self.logger.warning(
+            "[ReasoningTranslationSplitTracesTask] ID:%s Dumping unsuccessful record after final retry: %s",
+            self.data.get("id"),
+            message,
+        )
+        return self.build_result(
+            success=False,
+            error=message,
+            error_type=error_type,
+            **payload,
+        )
+
+    @staticmethod
+    @lru_cache(maxsize=1)
+    def get_tokenizer():
+        """Load tokenizer once per worker."""
+        # Import here to avoid global dependency if not used
+        from transformers import AutoTokenizer
+        if MODEL is None:
+            raise ValueError("MODEL environment variable must be set to use tokenizer")
+        return AutoTokenizer.from_pretrained(
+            MODEL,
+            trust_remote_code=True,
+        )
+
+    @staticmethod
+    def _split_traces_and_answer(output: str) -> tuple[str, str] | None:
+        match = THINK_BLOCK_PATTERN.match(output)
+        if match is None:
+            return None
+        return match.group("traces").strip(), match.group("answer").strip()
+
+    @staticmethod
+    def _reconstruct_traces(translated_trace_body: str, translated_answer: str) -> str:
+        return f"<think>{translated_trace_body}</think>{translated_answer}"
+
+    def _check_redacted_reasoning_tag(self, translation: str, issues: list[dict]) -> bool:
+        """Check if translation starts with <think> tag. Appends issue to list if not. Returns True if pass."""
+        pattern = r'^\s*<think>'
+        if not re.match(pattern, translation):
+            issues.append({"type": TranslationIssueType.MISSING_OPEN_THINK_TAG, "params": {}})
+            return False
+        return True
+
+    def _check_think_tags_structure(self, translation: str, issues: list[dict]) -> bool:
+        """Check that translation has exactly one <think> and one </think> tag,
+        and that there is non-whitespace content after the closing </think> tag.
+        Appends issues to list for each failed check. Returns True if all pass."""
+        open_count = len(re.findall(r'<think>', translation))
+        close_count = len(re.findall(r'</think>', translation))
+
+        if open_count != 1:
+            issues.append({"type": TranslationIssueType.INVALID_OPEN_THINK_TAG_COUNT, "params": {}})
+            return False
+        if close_count != 1:
+            issues.append({"type": TranslationIssueType.INVALID_CLOSE_THINK_TAG_COUNT, "params": {}})
+            return False
+
+        # Only check content after </think> if exactly one closing tag exists
+        if close_count == 1:
+            after_close = translation.split('</think>', 1)[1]
+            if not after_close.strip():
+                issues.append({"type": TranslationIssueType.NO_CONTENT_AFTER_CLOSE_THINK_TAG, "params": {}})
+                return False
+        return True
+
+    def _check_token_count(self, original: str, translation: str, issues: list[dict]) -> bool:
+        """Check if token count delta is acceptable (delta should not be more than 5000).
+        Appends issue with params to list if delta exceeds threshold. Returns True if pass."""
+        tokenizer = self.get_tokenizer()
+        original_tokens = len(tokenizer.encode(original))
+        translation_tokens = len(tokenizer.encode(translation))
+        delta = original_tokens - translation_tokens
+        if delta > 5000:
+            issues.append({"type": TranslationIssueType.TOKEN_COUNT_DELTA_TOO_LARGE, "params": {
+                "delta": delta,
+                "original_tokens": original_tokens,
+                "translation_tokens": translation_tokens,
+            }})
+            return False
+        return True
+
+    # --------------- generator ---------------
+    def task_generator(self) -> Generator[Union[Request, List[Request]], Any, Dict[str, Any]]:
+        # self.data is prepopulated with the data from the jsonl row being processed
+        sample_id = self.data.get("id") or str(uuid.uuid4())
+        # Mutate self.data so build_result spreads the resolved id.
+        self.data["id"] = sample_id
+        self.logger.info(f"[ReasoningTranslationSplitTracesTask] ID:{sample_id} Processing sample")
+
+        # read prompt from input.content with "role"=="user"
+        prompt = next((item for item in self.data.get("input", []) if item.get("role") == "user"), {}).get("content", "")
+
+        original_output = str(self.data.get("output", {}))
+        split_output = self._split_traces_and_answer(original_output)
+        if split_output is None:
+            message = "Unable to split output into <think> trace body and answer"
+            self.logger.error(
+                "[ReasoningTranslationSplitTracesTask] ID:%s %s",
+                sample_id,
+                message,
+            )
+            if self.is_last_retry_attempt():
+                return self._failed_result(
+                    error_type=TranslationIssueType.UNABLE_TO_SPLIT_THINK_BLOCK,
+                    message=message,
+                )
+            raise TaskRetry(message=message)
+
+        trace_body, answer = split_output
+
+        prompt_messages = [
+            {
+                "role": "user",
+                "content": TRANSLATION_PROMPT.format(
+                    language=LANGUAGE_NAMES.get(LANGUAGE, ["Finnish"])[0],
+                    text=prompt
+                )
+            }
+        ]
+        trace_messages = [
+            {
+                "role": "user",
+                "content": TRANSLATION_PROMPT.format(
+                    language=LANGUAGE_NAMES.get(LANGUAGE, ["Finnish"])[0],
+                    text=trace_body
+                )
+            }
+        ]
+        answer_messages = [
+            {
+                "role": "user",
+                "content": TRANSLATION_PROMPT.format(
+                    language=LANGUAGE_NAMES.get(LANGUAGE, ["Finnish"])[0],
+                    text=answer
+                )
+            }
+        ]
+
+        responses = yield [
+            Request(
+                {"messages": prompt_messages, **self.PROMPT_TRANSLATION_GEN_PARAMS},
+                context={
+                    "task": "reasoning_translation_split_traces",
+                    "sample_id": sample_id,
+                    "part": "prompt",
+                },
+            ),
+            Request(
+                {"messages": trace_messages, **self.TRACES_TRANSLATION_GEN_PARAMS},
+                context={
+                    "task": "reasoning_translation_split_traces",
+                    "sample_id": sample_id,
+                    "part": "trace_body",
+                },
+            ),
+            Request(
+                {"messages": answer_messages, **self.ANSWER_TRANSLATION_GEN_PARAMS},
+                context={
+                    "task": "reasoning_translation_split_traces",
+                    "sample_id": sample_id,
+                    "part": "answer",
+                },
+            ),
+        ]
+        responses_by_part = {
+            response.request.context["part"]: response for response in responses
+        }
+        prompt_resp = responses_by_part["prompt"]
+        trace_resp = responses_by_part["trace_body"]
+        answer_resp = responses_by_part["answer"]
+
+        if not prompt_resp.is_success:
+            self.logger.error(
+                "[ReasoningTranslationSplitTracesTask] ID:%s Prompt translation request failed: %s",
+                sample_id,
+                prompt_resp.error,
+            )
+            raise TaskRetry(message=f"Prompt translation request failed: {prompt_resp.error}")
+
+        translated_prompt_text = prompt_resp.get_text()
+        if translated_prompt_text is None:
+            self.logger.error(
+                "[ReasoningTranslationSplitTracesTask] ID:%s Prompt translation response had no extractable text payload",
+                sample_id,
+            )
+            raise TaskRetry(
+                message="Prompt translation response had no extractable text payload"
+            )
+
+        translated_prompt = translated_prompt_text.strip()
+
+        if not trace_resp.is_success:
+            self.logger.error(
+                "[ReasoningTranslationSplitTracesTask] ID:%s Trace body translation request failed: %s",
+                sample_id,
+                trace_resp.error,
+            )
+            if self.is_last_retry_attempt():
+                return self._failed_result(
+                    error_type="trace_body_translation_error",
+                    message=f"Trace body translation request failed: {trace_resp.error}",
+                    translated_prompt=translated_prompt,
+                )
+            raise TaskRetry(message=f"Trace body translation request failed: {trace_resp.error}")
+
+        if not answer_resp.is_success:
+            self.logger.error(
+                "[ReasoningTranslationSplitTracesTask] ID:%s Answer translation request failed: %s",
+                sample_id,
+                answer_resp.error,
+            )
+            if self.is_last_retry_attempt():
+                return self._failed_result(
+                    error_type="answer_translation_error",
+                    message=f"Answer translation request failed: {answer_resp.error}",
+                    translated_prompt=translated_prompt,
+                )
+            raise TaskRetry(message=f"Answer translation request failed: {answer_resp.error}")
+
+        translated_trace_body_text = trace_resp.get_text()
+        if translated_trace_body_text is None:
+            message = "Trace body translation response had no extractable text payload"
+            self.logger.error(
+                "[ReasoningTranslationSplitTracesTask] ID:%s %s",
+                sample_id,
+                message,
+            )
+            if self.is_last_retry_attempt():
+                return self._failed_result(
+                    error_type="trace_body_translation_response_parsing_error",
+                    message=message,
+                    translated_prompt=translated_prompt,
+                )
+            raise TaskRetry(message=message)
+
+        translated_answer_text = answer_resp.get_text()
+        if translated_answer_text is None:
+            message = "Answer translation response had no extractable text payload"
+            self.logger.error(
+                "[ReasoningTranslationSplitTracesTask] ID:%s %s",
+                sample_id,
+                message,
+            )
+            if self.is_last_retry_attempt():
+                return self._failed_result(
+                    error_type="answer_translation_response_parsing_error",
+                    message=message,
+                    translated_prompt=translated_prompt,
+                )
+            raise TaskRetry(message=message)
+
+        translated_traces = self._reconstruct_traces(
+            translated_trace_body_text.strip(),
+            translated_answer_text.strip(),
+        )
+
+        issues = []
+        if not self._check_token_count(original_output, translated_traces, issues):
+            issue_types = ", ".join(i["type"] for i in issues)
+            if self.is_last_retry_attempt():
+                return self._failed_result(
+                    error_type="trace_translation_validation_failed",
+                    message=f"Trace translation validation failed: {issue_types}",
+                    translated_prompt=translated_prompt,
+                    translated_traces=translated_traces,
+                )
+            raise TaskRetry(message=f"Trace translation validation failed: {issue_types}")
+
+        self.logger.info(
+            f"[ReasoningTranslationSplitTracesTask] ID:{sample_id} Finished processing sample"
+        )
+
+        return self.build_result(
+            translated_prompt=translated_prompt,
+            translated_traces=translated_traces,
+        )

--- a/examples/inference/tasks/reasoning_translation_task.py
+++ b/examples/inference/tasks/reasoning_translation_task.py
@@ -1,0 +1,330 @@
+"""
+Task description: Translates reasoning traces line-by-line from generated reasoning answers.
+"""
+from typing import Any, Dict, Generator, List, Union
+from functools import lru_cache
+
+from dispatcher.taskmanager.backend.request import Request, Response
+from dispatcher.taskmanager.task.base import GeneratorTask
+from dispatcher.taskmanager.task import TaskRetry
+
+import os
+import logging
+import re
+import uuid
+
+__all__ = ["ReasoningTranslationTask"]
+
+LANGUAGE = os.environ.get("LANGUAGE")
+MODEL = os.environ.get("MODEL")
+
+def _env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    return int(value) if value else default
+
+
+PROMPT_TRANSLATION_MAX_TOKENS = _env_int("PROMPT_TRANSLATION_MAX_TOKENS", 8192)
+TRACE_TRANSLATION_MAX_TOKENS = _env_int("TRACE_TRANSLATION_MAX_TOKENS", 32768)
+THOUGHT_START_MASK = "[THOUGHT_START]"
+THOUGHT_END_MASK = "[THOUGHT_END]"
+THINK_TAG_PATTERN = re.compile(r"</?think>")
+
+LANGUAGE_NAMES = {
+    "bg": ["Bulgarian", "bul"],
+    "cs": ["Czech", "ces"],
+    "da": ["Danish", "dan"],
+    "de": ["German", "deu"],
+    "el": ["Greek", "ell"],
+    "en": ["English", "eng"],
+    "es": ["Spanish", "spa"],
+    "et": ["Estonian", "est"],
+    "fi": ["Finnish", "fin"],
+    "fr": ["French", "fra"],
+    "ga": ["Irish", "gle"],
+    "hr": ["Croatian", "hrv"],
+    "hu": ["Hungarian", "hun"],
+    "it": ["Italian", "ita"],
+    "lt": ["Lithuanian", "lit"],
+    "lv": ["Latvian", "lav"],
+    "mt": ["Maltese", "mlt"],
+    "nl": ["Dutch", "nld"],
+    "pl": ["Polish", "pol"],
+    "pt": ["Portuguese", "por"],
+    "ro": ["Romanian", "ron"],
+    "sk": ["Slovak", "slk"],
+    "sl": ["Slovenian", "slv"],
+    "sv": ["Swedish", "swe"],
+    "is": ["Icelandic", "isl"],
+    "no": ["Norwegian", "nob"],
+}
+
+TRANSLATION_PROMPT = """
+You are a professional translator specializing in mathematics and scientific texts. Your task is to translate the following content faithfully and accurately into {language}.
+
+Guidelines:
+
+1. Preserve all LaTeX code, equations, symbols, and formatting exactly as written.
+2. Translate only the surrounding natural language, not the math expressions inside \( ... \), \[ ... \], or $$ ... $$.
+3. Maintain the precise meaning, tone, and logical structure of the original text.
+4. Use the standard mathematical terminology of the target language.
+5. Do not simplify, interpret, or solve the math; your goal is linguistic translation only.
+6. Keep variable names, constants, and notation unchanged.
+7. If an English math term has multiple valid equivalents in the target language, choose the most widely accepted in academic usage.
+8. Do not explain your translation; output only the translated text unless asked otherwise.
+9. Preserve the `[THOUGHT_START]` and `[THOUGHT_END]` masks exactly in the resulting text in the same positions as in the original input. Do not translate or alter these masks.
+
+Text to translate:
+{text}
+"""
+
+
+class TranslationIssueType:
+    """Standardized issue types for translation validation."""
+    MISSING_OPEN_THINK_TAG = "missing_open_think_tag"
+    INVALID_OPEN_THINK_TAG_COUNT = "invalid_open_think_tag_count"
+    INVALID_CLOSE_THINK_TAG_COUNT = "invalid_close_think_tag_count"
+    NO_CONTENT_AFTER_CLOSE_THINK_TAG = "no_content_after_close_think_tag"
+    TOKEN_COUNT_DELTA_TOO_LARGE = "token_count_delta_too_large"
+
+
+class ReasoningTranslationTask(GeneratorTask):
+    """Translation of prompts + reasoning traces."""
+
+
+    PROMPT_TRANSLATION_GEN_PARAMS: Dict[str, Any] = {
+        "temperature": 0.7,
+        "top_p": 0.95,
+        "max_tokens": PROMPT_TRANSLATION_MAX_TOKENS,
+    }
+
+    TRACES_TRANSLATION_GEN_PARAMS: Dict[str, Any] = {
+        "temperature": 0.7,
+        "top_p": 0.95,
+        "max_tokens": TRACE_TRANSLATION_MAX_TOKENS,
+    }
+
+    logger = logging.getLogger(__name__)
+
+    @staticmethod
+    def _mask_think_tags(text: str) -> str:
+        """Replace reasoning tags with masks before translation."""
+        return THINK_TAG_PATTERN.sub(
+            lambda match: THOUGHT_END_MASK if match.group(0) == "</think>" else THOUGHT_START_MASK,
+            text,
+        )
+
+    @staticmethod
+    def _restore_think_tags(text: str) -> str:
+        """Restore reasoning tags after translation."""
+        text = re.sub(re.escape(THOUGHT_START_MASK), "<think>", text)
+        return re.sub(re.escape(THOUGHT_END_MASK), "</think>", text)
+
+    def _failed_result(self, *, error_type: str, message: str, **payload: Any) -> Dict[str, Any]:
+        """Wrap Task.build_result so every failure call site logs uniformly."""
+        self.logger.warning(
+            "[ReasoningTranslationTask] ID:%s Dumping unsuccessful record after final retry: %s",
+            self.data.get("id"),
+            message,
+        )
+        return self.build_result(
+            success=False,
+            error=message,
+            error_type=error_type,
+            **payload,
+        )
+
+    @staticmethod
+    @lru_cache(maxsize=1)
+    def get_tokenizer():
+        """Load tokenizer once per worker."""
+        # Import here to avoid global dependency if not used
+        from transformers import AutoTokenizer
+        if MODEL is None:
+            raise ValueError("MODEL environment variable must be set to use tokenizer")
+        return AutoTokenizer.from_pretrained(
+            MODEL,
+            trust_remote_code=True,
+        )
+
+    def _check_redacted_reasoning_tag(self, translation: str, issues: list[dict]) -> bool:
+        """Check if translation starts with <think> tag. Appends issue to list if not. Returns True if pass."""
+        pattern = r'^\s*<think>'
+        if not re.match(pattern, translation):
+            issues.append({"type": TranslationIssueType.MISSING_OPEN_THINK_TAG, "params": {}})
+            return False
+        return True
+
+    def _check_think_tags_structure(self, translation: str, issues: list[dict]) -> bool:
+        """Check that translation has exactly one <think> and one </think> tag,
+        and that there is non-whitespace content after the closing </think> tag.
+        Appends issues to list for each failed check. Returns True if all pass."""
+        open_count = len(re.findall(r'<think>', translation))
+        close_count = len(re.findall(r'</think>', translation))
+
+        if open_count != 1:
+            issues.append({"type": TranslationIssueType.INVALID_OPEN_THINK_TAG_COUNT, "params": {}})
+            return False
+        if close_count != 1:
+            issues.append({"type": TranslationIssueType.INVALID_CLOSE_THINK_TAG_COUNT, "params": {}})
+            return False
+
+        # Only check content after </think> if exactly one closing tag exists
+        if close_count == 1:
+            after_close = translation.split('</think>', 1)[1]
+            if not after_close.strip():
+                issues.append({"type": TranslationIssueType.NO_CONTENT_AFTER_CLOSE_THINK_TAG, "params": {}})
+                return False
+        return True
+
+    def _check_token_count(self, original: str, translation: str, issues: list[dict]) -> bool:
+        """Check if token count delta is acceptable (delta should not be more than 5000).
+        Appends issue with params to list if delta exceeds threshold. Returns True if pass."""
+        tokenizer = self.get_tokenizer()
+        original_tokens = len(tokenizer.encode(original))
+        translation_tokens = len(tokenizer.encode(translation))
+        delta = original_tokens - translation_tokens
+        if delta > 5000:
+            issues.append({"type": TranslationIssueType.TOKEN_COUNT_DELTA_TOO_LARGE, "params": {
+                "delta": delta,
+                "original_tokens": original_tokens,
+                "translation_tokens": translation_tokens,
+            }})
+            return False
+        return True
+
+    
+    # --------------- generator ---------------
+    def task_generator(self) -> Generator[Union[Request, List[Request]], Any, Dict[str, Any]]:
+        # self.data is prepopulated with the data from the jsonl row being processed
+        # Get the generated reasoning answer
+        sample_id = self.data.get("id") or str(uuid.uuid4())
+        # Mutate self.data so build_result spreads the resolved id.
+        self.data["id"] = sample_id
+        self.logger.info(f"[ReasoningTranslationTask] ID:{sample_id} Processing sample")
+
+        # read prompt from input.content with "role"=="user"
+        prompt = next((item for item in self.data.get("input", []) if item.get("role") == "user"), {}).get("content", "")
+
+        # read traces from output
+        traces = self.data.get("output", {})
+        self.logger.info(f"[ReasoningTranslationTask] ID:{sample_id} Masking think tags")
+        masked_traces = self._mask_think_tags(str(traces))
+
+        prompt_messages = [
+            {
+                "role": "user", 
+                "content": TRANSLATION_PROMPT.format(
+                    language=LANGUAGE_NAMES.get(LANGUAGE, ["Finnish"])[0], 
+                    text=prompt
+                )
+            }
+        ]
+        trace_messages = [
+            {
+                "role": "user",
+                "content": TRANSLATION_PROMPT.format(
+                    language=LANGUAGE_NAMES.get(LANGUAGE, ["Finnish"])[0],
+                    text=masked_traces
+                )
+            }
+        ]
+
+        responses = yield [
+            Request(
+                {"messages": prompt_messages, **self.PROMPT_TRANSLATION_GEN_PARAMS},
+                context={
+                    "task": "reasoning_translation",
+                    "sample_id": sample_id,
+                    "part": "prompt",
+                },
+            ),
+            Request(
+                {"messages": trace_messages, **self.TRACES_TRANSLATION_GEN_PARAMS},
+                context={
+                    "task": "reasoning_translation",
+                    "sample_id": sample_id,
+                    "part": "traces",
+                },
+            ),
+        ]
+        responses_by_part = {
+            response.request.context["part"]: response for response in responses
+        }
+        prompt_resp = responses_by_part["prompt"]
+        trace_resp = responses_by_part["traces"]
+
+        if not prompt_resp.is_success:
+            self.logger.error(
+                "[ReasoningTranslationTask] ID:%s Prompt translation request failed: %s",
+                sample_id,
+                prompt_resp.error,
+            )
+            raise TaskRetry(message=f"Prompt translation request failed: {prompt_resp.error}")
+
+        translated_prompt_text = prompt_resp.get_text()
+        if translated_prompt_text is None:
+            self.logger.error(
+                "[ReasoningTranslationTask] ID:%s Prompt translation response had no extractable text payload",
+                sample_id,
+            )
+            raise TaskRetry(
+                message="Prompt translation response had no extractable text payload"
+            )
+
+        translated_prompt = translated_prompt_text.strip()
+
+        if not trace_resp.is_success:
+            self.logger.error(
+                "[ReasoningTranslationTask] ID:%s Trace translation request failed: %s",
+                sample_id,
+                trace_resp.error,
+            )
+            if self.is_last_retry_attempt():
+                return self._failed_result(
+                    error_type="traces_translation_error",
+                    message=f"Trace translation request failed: {trace_resp.error}",
+                    translated_prompt=translated_prompt,
+                )
+            raise TaskRetry(message=f"Trace translation request failed: {trace_resp.error}")
+
+        translated_traces_text = trace_resp.get_text()
+        if translated_traces_text is None:
+            self.logger.error(
+                "[ReasoningTranslationTask] ID:%s Trace translation response had no extractable text payload",
+                sample_id,
+            )
+            if self.is_last_retry_attempt():
+                return self._failed_result(
+                    error_type="traces_translation_response_parsing_error",
+                    message="Trace translation response had no extractable text payload",
+                    translated_prompt=translated_prompt,
+                )
+            raise TaskRetry(
+                message="Trace translation response had no extractable text payload"
+            )
+
+        self.logger.info(f"[ReasoningTranslationTask] ID:{sample_id} Restoring think tags")
+        translated_traces = self._restore_think_tags(translated_traces_text.strip())
+
+        issues = []
+        if not (self._check_redacted_reasoning_tag(translated_traces, issues)
+                and self._check_think_tags_structure(translated_traces, issues)
+                and self._check_token_count(str(traces), translated_traces, issues)):
+            issue_types = ", ".join(i["type"] for i in issues)
+            if self.is_last_retry_attempt():
+                return self._failed_result(
+                    error_type="trace_translation_validation_failed",
+                    message=f"Trace translation validation failed: {issue_types}",
+                    translated_prompt=translated_prompt,
+                    translated_traces=translated_traces,
+                )
+            raise TaskRetry(message=f"Trace translation validation failed: {issue_types}")
+
+        self.logger.info(
+            f"[ReasoningTranslationTask] ID:{sample_id} Finished processing sample"
+        )
+
+        return self.build_result(
+            translated_prompt=translated_prompt,
+            translated_traces=translated_traces,
+        )

--- a/examples/inference/tw_singularity_launcher.sh
+++ b/examples/inference/tw_singularity_launcher.sh
@@ -1,0 +1,326 @@
+#!/bin/bash
+# Launcher library for SLURM jobs with Singularity containers
+# Source this file in your SLURM job scripts to avoid duplicating container setup code
+
+###############################################################################
+# Configuration Variables (can be overridden before sourcing this file)
+###############################################################################
+
+# Default container and cache paths
+# : "${LAUNCHER_IMG:=/shared_silo/scratch/containers/rocm_vllm_rocm7.0.0_vllm_0.11.1_20251103.sif}"
+: "${LAUNCHER_IMG:=/shared_silo/scratch/containers/vllm-openai-rocm-gemma4.sif}"
+: "${LAUNCHER_PYEXEC_IN_IMG:=python3}"
+: "${LAUNCHER_PYTHON_VERSION:=3.12}"
+: "${LAUNCHER_HF_HOME:=/shared_silo/scratch/models}"
+: "${LAUNCHER_TORCHINDUCTOR_CACHE:=/tmp/$USER/$SLURM_JOB_ID/torch_inductor_cache}"
+: "${LAUNCHER_MODELS_BIND_MODE:=rw}"
+
+# Offline mode flags (set to empty string to disable)
+: "${LAUNCHER_HF_HUB_OFFLINE:=}"
+: "${LAUNCHER_TRANSFORMERS_OFFLINE:=}"
+
+###############################################################################
+# setup_singularity_environment()
+# Sets up all environment variables and paths for Singularity container execution
+###############################################################################
+setup_singularity_environment() {
+  # Create necessary directories
+  mkdir -p logs pythonuserbase
+
+  # Caches MUST be on writable, node-local paths. Scope them by user and
+  # Slurm job so stale cache parents from other users cannot block mkdir.
+  export HF_HOME="$LAUNCHER_HF_HOME"
+  export TRANSFORMERS_CACHE="$HF_HOME"
+  export TORCHINDUCTOR_CACHE="$LAUNCHER_TORCHINDUCTOR_CACHE"
+  install -d -m 700 "/tmp/$USER/$SLURM_JOB_ID" "/dev/shm/$USER/$SLURM_JOB_ID"
+  mkdir -p "$HF_HOME" "$TORCHINDUCTOR_CACHE"
+
+  # AITER JIT build root: opt-in to local FS to dodge WEKAFS flock semantics
+  # that deadlock AITER's FileBaton (see ROCm/aiter #1162). Set
+  # AITER_JIT_DIR_LOCAL=1 in the worker config for DeepSeek-V3 + FP8 etc.
+  if [ "${AITER_JIT_DIR_LOCAL:-0}" = "1" ]; then
+    export AITER_JIT_DIR="/tmp/$USER/$SLURM_JOB_ID/aiter-jit"
+    mkdir -p "$AITER_JIT_DIR"
+  fi
+
+  # Set offline mode flags if configured
+  if [ -n "$LAUNCHER_HF_HUB_OFFLINE" ]; then
+    export HF_HUB_OFFLINE="$LAUNCHER_HF_HUB_OFFLINE"
+  fi
+  if [ -n "$LAUNCHER_TRANSFORMERS_OFFLINE" ]; then
+    export TRANSFORMERS_OFFLINE="$LAUNCHER_TRANSFORMERS_OFFLINE"
+  fi
+
+  # Container and Python paths
+  export IMG="$LAUNCHER_IMG"
+  export PYEXEC_IN_IMG="$LAUNCHER_PYEXEC_IN_IMG"
+  export PIP_IN_IMG="$PYEXEC_IN_IMG -m pip"
+
+  # Compilers for Triton/Inductor
+  if command -v /opt/rocm/llvm/bin/clang++ >/dev/null 2>&1; then
+    export CC="/opt/rocm/llvm/bin/clang"
+    export CXX="/opt/rocm/llvm/bin/clang++"
+  else
+    export CC="/opt/rocm/bin/hipcc"
+    export CXX="/opt/rocm/bin/hipcc"
+  fi
+
+  # Paths inside the container
+  export PYUSERBASE="/workspace/pythonuserbase"
+  export PYUSERPKG="$PYUSERBASE/lib/python${LAUNCHER_PYTHON_VERSION}/site-packages"
+
+  # --- Define a 100% clean PATH for the container ---
+  # This stops inheriting host paths that can cause issues
+  CONTAINER_PATH="/opt/rocm/llvm/bin:/opt/rocm/bin"
+  CONTAINER_PATH="$CONTAINER_PATH:/opt/miniconda3/envs/pytorch/bin"
+  CONTAINER_PATH="$CONTAINER_PATH:/usr/local/bin:/usr/bin:/bin"
+  export SINGULARITYENV_PATH="$CONTAINER_PATH"
+
+  # HF token: read from env, then fall back to the default cached token file
+  if [ -z "${HF_TOKEN:-}" ]; then
+    local _token_file="$HOME/.cache/huggingface/token"
+    if [ -f "$_token_file" ]; then
+      HF_TOKEN="$(cat "$_token_file")"
+    fi
+  fi
+  if [ -n "${HF_TOKEN:-}" ]; then
+    { set +x; } 2>/dev/null
+    export SINGULARITYENV_HF_TOKEN="$HF_TOKEN"
+    set -x
+  fi
+
+  # Pass all required ENVs into the container
+  export SINGULARITYENV_CC="$CC"
+  export SINGULARITYENV_CXX="$CXX"
+  export SINGULARITYENV_USER="$USER"
+  export SINGULARITYENV_HF_HOME="$HF_HOME"
+  export SINGULARITYENV_TRANSFORMERS_CACHE="$TRANSFORMERS_CACHE"
+  export SINGULARITYENV_TORCHINDUCTOR_CACHE="$TORCHINDUCTOR_CACHE"
+  if [ -n "${AITER_JIT_DIR:-}" ]; then
+    export SINGULARITYENV_AITER_JIT_DIR="$AITER_JIT_DIR"
+  fi
+  export SINGULARITYENV_PYTHONUSERBASE="$PYUSERBASE"
+  export SINGULARITYENV_PYTHONPATH="$PYUSERPKG:\${PYTHONPATH-}"
+  export SINGULARITYENV_PYEXEC_IN_IMG="$PYEXEC_IN_IMG"
+  export SINGULARITYENV_DISPATCHER_SERVER="${DISPATCHER_SERVER}"
+  export SINGULARITYENV_DISPATCHER_PORT="${DISPATCHER_PORT}"
+  
+  if [ -n "${HF_HUB_OFFLINE:-}" ]; then
+    export SINGULARITYENV_HF_HUB_OFFLINE="$HF_HUB_OFFLINE"
+  fi
+  if [ -n "${TRANSFORMERS_OFFLINE:-}" ]; then
+    export SINGULARITYENV_TRANSFORMERS_OFFLINE="$TRANSFORMERS_OFFLINE"
+  fi
+
+  # vLLM/ROCm flags
+  # based on https://rocm.docs.amd.com/en/docs-7.0-docker/benchmark-docker/inference-vllm-deepseek-r1-fp8.html
+  # Note: this flag VLLM_ROCM_QUICK_REDUCE_QUANTIZATION may not be compatible with MI325X GPUs
+  # export SINGULARITYENV_VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4
+  export SINGULARITYENV_VLLM_USE_V1=${VLLM_USE_V1:-1}
+  export SINGULARITYENV_VLLM_ROCM_USE_AITER=${VLLM_ROCM_USE_AITER:-1}
+  export SINGULARITYENV_VLLM_TARGET_DEVICE=rocm
+  export SINGULARITYENV_VLLM_WORKER_MULTIPROC_METHOD=spawn
+  export SINGULARITYENV_HIP_ARCHITECTURES=gfx942
+  
+  # Worker environment variables (for use inside container)
+  export SINGULARITYENV_TORCH_EXTENSIONS_DIR="/dev/shm/$USER/$SLURM_JOB_ID/torch_ext"
+  export SINGULARITYENV_PYTHONNOUSERSITE=
+}
+
+###############################################################################
+# get_binds
+# Returns bind mount arguments as an array
+# This function-based approach ensures BINDS are always available regardless of sourcing context
+###############################################################################
+get_binds() {
+  local binds=(
+    -B /shared_silo/scratch/adamhrin@amd.com:/shared_silo/scratch/adamhrin@amd.com:rw
+    -B /shared_silo/scratch/models:/shared_silo/scratch/models:$LAUNCHER_MODELS_BIND_MODE
+    -B /shared_silo/scratch/datasets:/shared_silo/scratch/datasets:ro
+    -B /shared_silo/scratch/kahakala:/shared_silo/scratch/kahakala:ro
+    -B "${PWD:-$(pwd)}:/workspace"
+  )
+  if [ -f /usr/share/libdrm/amdgpu.ids ]; then
+    binds+=(-B /usr/share/libdrm:/usr/share/libdrm:ro)
+  fi
+  printf '%s\n' "${binds[@]}"
+}
+# Export function so it's available in srun workers
+export -f get_binds
+
+###############################################################################
+# install_build_dependencies
+# Installs ninja (parallel build system for JIT-compiled GPU kernels)
+###############################################################################
+install_build_dependencies() {
+  local binds_array
+  mapfile -t binds_array < <(get_binds)
+  singularity exec --rocm --cleanenv "${binds_array[@]}" "$IMG" bash --noprofile --norc -c \
+    "$PIP_IN_IMG install --user ninja"
+}
+
+###############################################################################
+# setup_cleanup_trap
+# Sets up cleanup trap to kill server process on exit
+###############################################################################
+setup_cleanup_trap() {
+  trap 'kill "${srv_pid:-0}" 2>/dev/null || true' EXIT
+}
+
+###############################################################################
+# translate_slurm_vars
+# Translates SLURM_* environment variables to SINGULARITYENV_* versions
+# so they pass through --cleanenv
+###############################################################################
+translate_slurm_vars() {
+  local var
+  for var in SLURM_PROCID SLURM_LOCALID SLURM_STEP_ID SLURM_STEP_TASK_ID SLURM_JOB_ID SLURM_NODEID SLURM_NTASKS; do
+    if [ -n "${!var:-}" ]; then
+      export "SINGULARITYENV_${var}=${!var}"
+    fi
+  done
+}
+# Export function so it's available in srun workers
+export -f translate_slurm_vars
+
+###############################################################################
+# Complete environment setup
+###############################################################################
+setup_launcher_environment() {
+  translate_slurm_vars
+  setup_singularity_environment
+  install_build_dependencies
+  setup_cleanup_trap
+}
+
+###############################################################################
+# run_sing_bash
+# Helper function to run bash commands inside the Singularity container
+# Automatically translates SLURM_* variables to SINGULARITYENV_* before execution
+# Automatically sets up worker environment inline (no external script needed)
+# Usage: run_sing_bash "command to run"
+###############################################################################
+run_sing_bash() {
+  [ -n "${IMG:-}" ] || {
+    echo "[singularity_launcher] ERROR: run_sing_bash called before setup_singularity_environment" >&2
+    return 1
+  }
+  translate_slurm_vars
+  # Use get_binds() function to get bind mounts - works regardless of sourcing context
+  local binds_array
+  mapfile -t binds_array < <(get_binds)
+  # Build inline environment setup command
+  # This sets up the worker environment directly without needing an external script
+  local env_setup="
+    # Set HOME to /workspace
+    export HOME=/workspace
+    
+    # Import container configuration from SINGULARITYENV_* variables
+    export HF_HOME=\"\${HF_HOME:-}\"
+    export TRANSFORMERS_CACHE=\"\${TRANSFORMERS_CACHE:-}\"
+    export TORCHINDUCTOR_CACHE=\"\${TORCHINDUCTOR_CACHE:-}\"
+    export HF_HUB_OFFLINE=\"\${HF_HUB_OFFLINE:-}\"
+    export TRANSFORMERS_OFFLINE=\"\${TRANSFORMERS_OFFLINE:-}\"
+    export CC=\"\${CC:-}\"
+    export CXX=\"\${CXX:-}\"
+    export PYEXEC_IN_IMG=\"\${PYEXEC_IN_IMG:-}\"
+    
+    # Setup Python environment
+    export PYTHONUSERBASE=\"\${PYTHONUSERBASE:-/workspace/pythonuserbase}\"
+    export PATH=\"\$PYTHONUSERBASE/bin:\$PATH\"
+    # AIter JIT writes importable artifacts into a writable install root.
+    # Without this, it may attempt to write into system site-packages and later fail imports like:
+    #   No module named 'aiter.jit.module_gemm_common'
+    export AITER_INSTALL=\"\$HOME/.aiter/jit/install\"
+    mkdir -p \"\$AITER_INSTALL\" 2>/dev/null || true
+    # Clean up stale shadow directories from previous runs that would shadow
+    # the real aiter package (empty aiter/ dir on PYTHONPATH acts as a
+    # namespace package and hides the real one from dist-packages).
+    rm -rf \"\$AITER_INSTALL/aiter\" \"\$AITER_INSTALL/private_aiter\" 2>/dev/null || true
+    export PYTHONPATH=\"\$PYTHONUSERBASE/lib/python${LAUNCHER_PYTHON_VERSION}/site-packages:\$AITER_INSTALL:\${PYTHONPATH-}\"
+    export PYTHONNOUSERSITE=
+
+    # AIter JIT builds extension modules (e.g. module_gemm_common.so) under
+    # ~/.aiter/jit/ but the Python package aiter.jit lives under system
+    # dist-packages. We bridge that gap via a sitecustomize.py that extends
+    # aiter.jit.__path__ at interpreter startup.
+    cat >\"\$AITER_INSTALL/sitecustomize.py\" <<'PY'
+import os
+try:
+    import aiter.jit as _aj
+    _p = os.path.join(os.path.expanduser('~'), '.aiter', 'jit')
+    if os.path.isdir(_p) and _p not in list(getattr(_aj, '__path__', [])):
+        _aj.__path__.append(_p)
+except Exception:
+    pass
+PY
+    
+    # vLLM/ROCm flags
+    export VLLM_USE_V1=\${VLLM_USE_V1:-1}
+    export VLLM_ROCM_USE_AITER=\${VLLM_ROCM_USE_AITER:-1}
+    export VLLM_TARGET_DEVICE=\${VLLM_TARGET_DEVICE:-rocm}
+    export VLLM_WORKER_MULTIPROC_METHOD=\${VLLM_WORKER_MULTIPROC_METHOD:-spawn}
+    export HIP_ARCHITECTURES=\${HIP_ARCHITECTURES:-gfx942}
+
+    # from https://rocm.docs.amd.com/en/docs-7.0-docker/benchmark-docker/inference-vllm-deepseek-r1-fp8.html
+    # Note: this flag may not be compatible with MI325X GPUs
+    # export VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=\"\${VLLM_ROCM_QUICK_REDUCE_QUANTIZATION:-INT4}\"
+    
+    # Triton cache isolation (avoid multi-rank races on shared filesystems)
+    # Use per-user, per-job, per-rank cache dirs on node-local /tmp.
+    export TRITON_CACHE_DIR=\"/tmp/\$USER/\$SLURM_JOB_ID/triton_cache/\${SLURM_PROCID:-\${SLURM_LOCALID:-0}}\"
+    export XDG_CACHE_HOME=\"/tmp/\$USER/\$SLURM_JOB_ID/xdg_cache/\${SLURM_PROCID:-\${SLURM_LOCALID:-0}}\"
+    mkdir -p \"\$TRITON_CACHE_DIR\" \"\$XDG_CACHE_HOME\" 2>/dev/null || true
+
+    # Create necessary directories
+    export TORCH_EXTENSIONS_DIR=\"\${TORCH_EXTENSIONS_DIR:-/dev/shm/\$USER/\$SLURM_JOB_ID/torch_ext}\"
+    mkdir -p \"\$TORCH_EXTENSIONS_DIR\" 2>/dev/null || true
+    
+    # Define run_python helper function
+    run_python() {
+      \"\${PYEXEC_IN_IMG:-python3}\" \"\$@\"
+    }
+  "
+  # Execute command with inline environment setup
+  # Ensure we have at least one argument
+  if [ $# -eq 0 ]; then
+    echo "[singularity_launcher] ERROR: run_sing_bash called without command" >&2
+    return 1
+  fi
+  # Join all arguments with spaces (typical case: single multi-line command string)
+  local user_command="$*"
+  local full_command="$env_setup
+$user_command"
+  singularity exec --rocm --cleanenv "${binds_array[@]}" "$IMG" bash --noprofile --norc -c "$full_command"
+}
+# Export function so it's available in srun workers without needing to source the launcher
+export -f run_sing_bash
+
+###############################################################################
+# run_sing_python
+# Helper function to run Python commands inside the Singularity container
+# PYTHONPATH is already configured via SINGULARITYENV_PYTHONPATH from setup_singularity_environment
+# Usage: run_sing_python -m module.name --arg1 val1 --arg2 val2
+###############################################################################
+run_sing_python() {
+  [ -n "${IMG:-}" ] && [ -n "${PYEXEC_IN_IMG:-}" ] || {
+    echo "[singularity_launcher] ERROR: run_sing_python called before setup_singularity_environment" >&2
+    return 1
+  }
+  # Use get_binds() function to get bind mounts - works regardless of sourcing context
+  local binds_array
+  mapfile -t binds_array < <(get_binds)
+  singularity exec --rocm --cleanenv "${binds_array[@]}" "$IMG" "$PYEXEC_IN_IMG" "$@"
+}
+
+###############################################################################
+# is_inside_container
+# Detects if we're running inside a Singularity container
+# Returns 0 if inside container, 1 if not
+###############################################################################
+is_inside_container() {
+  [ -n "${SINGULARITY_NAME:-}" ] || [ -f /.singularity.d/env/99-base.sh ]
+}
+
+# Run this when the script is sourced in the launcher
+setup_launcher_environment


### PR DESCRIPTION
Five task profiles backed by a shared dispatcher server + SLURM worker job: annotations, prompt-translation, sft-pipeline-stage5, translation, and translation-split-traces. All tasks use the new Task.build_result and Task.is_last_retry_attempt helpers for a consistent result schema.

The server can be run either on the login node via tmux (start_dispatcher_server.sh) or on a compute node via the sbatch wrapper (jobs/launch_dispatcher_server.sh).