### PR TITLE
Make --disable-log-requests opt-out for newer vLLM versions

### DIFF
--- a/dispatcher/taskmanager/backend/vllm.py
+++ b/dispatcher/taskmanager/backend/vllm.py
@@ -187,7 +187,8 @@ class VLLMBackendManager(BackendManager):
                  health_check_interval: int = 60,
                  disable_output: bool = False,
                  enforce_eager: bool = False,
-                 extra_vllm_args: Optional[List[str]] = None):
+                 extra_vllm_args: Optional[List[str]] = None,
+                 disable_log_requests: bool = True):
         """
         Initialize a VLLM backend manager.
         
@@ -234,7 +235,7 @@ class VLLMBackendManager(BackendManager):
                     chat_template=chat_template,
                     max_model_len=max_model_len,
                     startup_timeout=startup_timeout,
-                    disable_log_requests=True,
+                    disable_log_requests=disable_log_requests,
                     disable_output=disable_output,
                     enforce_eager=enforce_eager,
                     extra_vllm_args=extra_vllm_args,

--- a/dispatcher/taskmanager/cli.py
+++ b/dispatcher/taskmanager/cli.py
@@ -153,6 +153,7 @@ def run(
     silence_vllm_logs: bool = False,
     enforce_eager: bool = False,
     extra_vllm_args: Optional[List[str]] = None,
+    disable_log_requests: bool = True,
     # task manager params
     workers: int = 16,
     batch_size: int = 4,
@@ -192,6 +193,7 @@ def run(
         disable_output=silence_vllm_logs,
         enforce_eager=enforce_eager,
         extra_vllm_args=extra_vllm_args,
+        disable_log_requests=disable_log_requests,
     )
 
     manager = TaskManager(num_workers=workers)
@@ -240,6 +242,7 @@ def _build_parser() -> argparse.ArgumentParser:
     # vllm tuning
     p.add_argument("--enforce-eager", action="store_true", help="Force vLLM to run in eager mode")
     p.add_argument("--vllm-extra-args", type=str, default=None, help="Space-separated additional vLLM command-line arguments (e.g., '--block-size 1 --trust-remote-code') Supports shell-like quoting.")
+    p.add_argument("--no-disable-log-requests", dest="disable_log_requests", action="store_false", default=True, help="Skip --disable-log-requests (removed in newer vLLM).")
 
     # manager & batches
     p.add_argument("--workers", type=int, default=16)
@@ -276,6 +279,7 @@ def main(argv: Optional[list[str]] = None):
         silence_vllm_logs=args.silence_vllm_logs,
         enforce_eager=args.enforce_eager,
         extra_vllm_args=extra_vllm_args,
+        disable_log_requests=args.disable_log_requests,
         workers=args.workers,
         batch_size=args.batch_size,
     )


### PR DESCRIPTION
## Summary

The dispatcher unconditionally appended `--disable-log-requests` on every vLLM launch. Recent vLLM releases removed that flag in favor of `--no-enable-log-requests`, so every worker against a current vLLM image now fails at startup with:

```
api_server.py: error: unrecognized arguments: --disable-log-requests
```

This PR exposes a `--no-disable-log-requests` CLI flag that suppresses the appending step. **Default behavior is unchanged**: callers that don't pass the new flag still append `--disable-log-requests`, so anyone on an older vLLM keeps working exactly as before.

## Changes

- `dispatcher/taskmanager/backend/vllm.py` — `VLLMBackendManager.__init__` accepts `disable_log_requests: bool = True` and forwards it to `VLLMServerManager.launch_and_wait`. The launch function already has the gate; this just unhardcodes the hardcoded `True` on the construction site.
- `dispatcher/taskmanager/cli.py` — adds `--no-disable-log-requests` (defaults to True; `store_false` flips it). Plumbed into `VLLMBackendManager(...)`.

Five touched lines total.

## Usage

| Setup | What to pass | Result |
| --- | --- | --- |
| Old vLLM, existing scripts | nothing (no change) | `--disable-log-requests` appended, identical to before |
| New vLLM, want quiet logs | `--no-disable-log-requests --vllm-extra-args "--no-enable-log-requests"` | dispatcher skips the old flag, vLLM gets the new one |
| New vLLM, don't care about logs | `--no-disable-log-requests` | dispatcher skips the old flag, vLLM uses its own default |

## Test plan

- [ ] Existing test suite passes (no behavior change for default callers).
- [ ] Manual: launch a worker against a current vLLM image with the new flag — vLLM should start without "unrecognized arguments".
- [ ] Manual: launch a worker against an older vLLM image without the new flag — should be byte-identical to current behavior.