### PR TITLE
Drop hardcoded --disable-log-requests; let users opt in via VLLM_EXTRA_ARGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,17 @@ dispatcher-task-run \
 
 The server exits automatically when all work is complete. If workers connect after the server has already exited (because a previous run finished all lines), they'll see `SERVER_UNAVAILABLE` and exit immediately. To reprocess, delete or rename the output file and checkpoint file, then restart the server.
 
+### vLLM startup fails with `unrecognized arguments: --disable-log-requests`
+
+Older dispatcher releases hardcoded `--disable-log-requests` on every vLLM launch. vLLM [PR #21739](https://github.com/vllm-project/vllm/pull/21739) renamed the flag to `--enable-log-requests` **and inverted the polarity** — request logging is now off by default. The dispatcher no longer adds either flag.
+
+| vLLM version | Default | Add to `--vllm-extra-args` if you want… |
+|---|---|---|
+| **< 0.10.1** (has `--disable-log-requests`) | request logging **on** | `"--disable-log-requests"` to suppress (this was the dispatcher's previous default) |
+| **≥ 0.10.1** (has `--enable-log-requests`) | request logging **off** | `"--enable-log-requests"` to enable |
+
+Most users on vLLM ≥ 0.10.1 don't need to add anything.
+
 ### Items are being reissued constantly
 
 Check `GET /status` — if `expired_reissues` is climbing, inferences are taking longer than `work_timeout`. Increase it live:

--- a/dispatcher/taskmanager/backend/vllm.py
+++ b/dispatcher/taskmanager/backend/vllm.py
@@ -53,7 +53,6 @@ class VLLMServerManager:
         chat_template: Optional[str],
         max_model_len: Optional[int],
         startup_timeout: int,
-        disable_log_requests: bool = True,
         disable_output: bool = False,
         enforce_eager: bool = False,
         extra_vllm_args: Optional[List[str]] = None,
@@ -71,7 +70,6 @@ class VLLMServerManager:
             chat_template: Optional path to a chat template file.
             max_model_len: Optional max model length override.
             startup_timeout: Max seconds to wait for the server to pass health check.
-            disable_log_requests: Whether to add --disable-log-requests flag.
             extra_vllm_args: Optional list of additional command-line arguments to pass to vLLM server.
 
         Returns:
@@ -90,8 +88,6 @@ class VLLMServerManager:
             "--gpu-memory-utilization", str(gpu_memory_utilization),
         ]
         
-        if disable_log_requests:
-            cmd.append("--disable-log-requests")
         if api_key:
             cmd.extend(["--api-key", api_key])
         if chat_template:
@@ -234,7 +230,6 @@ class VLLMBackendManager(BackendManager):
                     chat_template=chat_template,
                     max_model_len=max_model_len,
                     startup_timeout=startup_timeout,
-                    disable_log_requests=True,
                     disable_output=disable_output,
                     enforce_eager=enforce_eager,
                     extra_vllm_args=extra_vllm_args,


### PR DESCRIPTION
## Summary

The dispatcher unconditionally appended `--disable-log-requests` on every vLLM launch. vLLM [PR #21739](https://github.com/vllm-project/vllm/pull/21739) (merged Aug 2025, shipped in 0.10.1) renamed the flag to `--enable-log-requests` **and inverted the polarity** — request logging is now off by default. The flag was kept as a deprecated alias for one minor release and then removed in 0.12.0, so every worker against a current vLLM image fails at startup with:

```
api_server.py: error: unrecognized arguments: --disable-log-requests
```

### Rollout timeline

| vLLM version | `--disable-log-requests` | `--enable-log-requests` | Request-log default |
|---|---|---|---|
| < 0.10.1 | accepted | not present | **on** |
| 0.10.1 – 0.10.x | accepted (silently) | accepted | off |
| 0.11.x | accepted with deprecation warning (`This will be removed in v0.12.0`) | accepted | off |
| ≥ 0.12.0 | **rejected** (`unrecognized arguments`) | accepted | off |

## Approach: drop the opinion

The dispatcher no longer adds the flag at all. Request-log behavior follows whatever the installed vLLM defaults to. Users who want to override use the existing `--vllm-extra-args` escape hatch — that way the dispatcher doesn't need a code change every time vLLM renames a flag, and we don't leak vLLM-version knowledge into the dispatcher CLI.

## Changes

- `dispatcher/taskmanager/backend/vllm.py` — removed the `disable_log_requests` kwarg from `launch_and_wait`, removed the `if disable_log_requests: cmd.append(...)` block, removed the hardcoded `disable_log_requests=True` at the only call site, removed the docstring line. Five-line net removal.
- `README.md` — added a Troubleshooting entry with a per-version "which flag, if any, to put in `--vllm-extra-args`" table. The detailed rollout timeline lives here in the PR description rather than in the README.

## Behavior change

| User setup | Previous (dispatcher hardcoded) | New (this PR) | User action |
|---|---|---|---|
| vLLM < 0.10.1 | request logs suppressed | request logs on (vLLM default) | Add `--vllm-extra-args "--disable-log-requests"` to restore quiet behavior |
| vLLM 0.10.1 – 0.11.x | request logs suppressed (deprecation warning on 0.11.x) | quiet (vLLM default after polarity flip) | None — already quiet |
| vLLM ≥ 0.12.0 | **startup crash** | quiet (vLLM default) | None — fixed |

Most users on vLLM ≥ 0.10.1 see no functional difference; the dispatcher's previous "quiet by default" intent already matches vLLM's own default after PR #21739. Only users on pre-0.10.1 vLLM who relied on the dispatcher's suppression need to add one line to their worker config.

## Test plan

- [x] Full test suite passes (67 tests).
- [ ] Manual: launch a worker against a current vLLM image — no more "unrecognized arguments".
- [ ] Manual: launch a worker against a pre-0.10.1 vLLM image — starts identically; only difference is request logs now appear unless suppressed via `--vllm-extra-args`.