### PR TITLE
Nest build_result bookkeeping under task_metadata

### DIFF
--- a/dispatcher/taskmanager/task/base.py
+++ b/dispatcher/taskmanager/task/base.py
@@ -101,23 +101,28 @@ class Task(ABC):
         *,
         success: bool = True,
         error: Optional[str] = None,
+        error_type: Optional[str] = None,
         **payload: Any,
     ) -> Dict[str, Any]:
-        """Construct a result dict with the standard dispatcher fields filled in.
+        """Construct a result dict with bookkeeping kept out of the payload.
 
-        Layering (last wins): self.data -> standard fields -> caller payload.
-        Retry metadata is included automatically when the task source provides it.
+        Task bookkeeping (success / error / error_type / retry_count /
+        max_retries) is collected under a single ``task_metadata`` key so it
+        does not collide with the task's own output fields. Layering:
+        ``self.data`` -> caller payload -> ``task_metadata``.
         """
-        result: Dict[str, Any] = {**self.data, "success": success}
+        metadata: Dict[str, Any] = {"success": success}
         if error is not None:
-            result["error"] = error
+            metadata["error"] = error
+        if error_type is not None:
+            metadata["error_type"] = error_type
         retry_count = getattr(self.context, "retry_count", None)
         max_retries = getattr(self.context, "max_retries", None)
         if retry_count is not None:
-            result["retry_count"] = retry_count
+            metadata["retry_count"] = retry_count
         if max_retries is not None:
-            result["max_retries"] = max_retries
-        result.update(payload)
+            metadata["max_retries"] = max_retries
+        result: Dict[str, Any] = {**self.data, **payload, "task_metadata": metadata}
         return result
 
 ###############################################################################

--- a/tests/taskmanager/test_generator_task.py
+++ b/tests/taskmanager/test_generator_task.py
@@ -309,56 +309,82 @@ class TestIsLastRetryAttempt(unittest.TestCase):
 
 
 class TestBuildResult(unittest.TestCase):
-    """build_result() assembles the dispatcher's standard result schema."""
+    """build_result() assembles the task's standard schema under task_metadata."""
 
     def test_default_success_with_payload(self):
-        # success defaults to True; data is spread in; payload is merged.
+        # success defaults to True; data is spread in; payload is merged; metadata is nested.
         task = _make_task(data={"prompt": "hi"})
         self.assertEqual(
             task.build_result(translated="HI", score=0.9),
-            {"prompt": "hi", "success": True, "translated": "HI", "score": 0.9},
+            {
+                "prompt": "hi",
+                "translated": "HI",
+                "score": 0.9,
+                "task_metadata": {"success": True},
+            },
         )
         # Empty data still yields a valid minimal result.
-        self.assertEqual(_make_task().build_result(), {"success": True})
+        self.assertEqual(
+            _make_task().build_result(),
+            {"task_metadata": {"success": True}},
+        )
 
-    def test_failure_with_error_and_partial_payload(self):
+    def test_failure_with_error_error_type_and_partial_payload(self):
         task = _make_task(data={"prompt": "hi"})
         self.assertEqual(
-            task.build_result(success=False, error="boom", partial="HE"),
-            {"prompt": "hi", "success": False, "error": "boom", "partial": "HE"},
+            task.build_result(
+                success=False,
+                error="boom",
+                error_type="prompt_error",
+                partial="HE",
+            ),
+            {
+                "prompt": "hi",
+                "partial": "HE",
+                "task_metadata": {
+                    "success": False,
+                    "error": "boom",
+                    "error_type": "prompt_error",
+                },
+            },
         )
-        # error=None must be omitted, not serialized as null.
-        self.assertNotIn("error", task.build_result(success=False))
+        # error=None and error_type=None are omitted, not serialized as null.
+        result = task.build_result(success=False)
+        self.assertEqual(result["task_metadata"], {"success": False})
 
     def test_retry_metadata_included_with_edge_values(self):
         # retry_count=0 (first attempt) and max_retries=-1 (unlimited) are both
-        # meaningful and must surface in the result, not be dropped by a truthy check.
+        # meaningful and must surface in task_metadata, not be dropped by a truthy check.
         for retry_count, max_retries in [(2, 3), (0, 3), (5, -1)]:
             with self.subTest(retry_count=retry_count, max_retries=max_retries):
                 task = _make_task(context=_RetryCtx(retry_count, max_retries))
-                result = task.build_result()
-                self.assertEqual(result["retry_count"], retry_count)
-                self.assertEqual(result["max_retries"], max_retries)
+                metadata = task.build_result()["task_metadata"]
+                self.assertEqual(metadata["retry_count"], retry_count)
+                self.assertEqual(metadata["max_retries"], max_retries)
 
     def test_retry_metadata_omitted_when_context_lacks_attrs(self):
         for ctx in (None, {"line_number": 0}):
             with self.subTest(ctx=ctx):
-                result = _make_task(context=ctx).build_result()
-                self.assertNotIn("retry_count", result)
-                self.assertNotIn("max_retries", result)
+                metadata = _make_task(context=ctx).build_result()["task_metadata"]
+                self.assertNotIn("retry_count", metadata)
+                self.assertNotIn("max_retries", metadata)
 
-    def test_payload_overrides_data_and_standard_fields(self):
-        # Last-write-wins: caller payload trumps both self.data and the auto-filled
-        # retry fields, so a task can override defaults when it has better info.
+    def test_payload_and_data_do_not_collide_with_metadata(self):
+        # The whole point of nesting metadata: a task that already has a
+        # "success" or "retry_count" key in self.data (input row) can keep it
+        # at the top level without clobbering the dispatcher-managed values
+        # under task_metadata.
         task = _make_task(
-            data={"prompt": "original"},
+            data={"prompt": "original", "retry_count": "user-supplied"},
             context=_RetryCtx(retry_count=2, max_retries=3),
         )
-        result = task.build_result(prompt="overridden", retry_count=999)
-        self.assertEqual(result["prompt"], "overridden")
-        self.assertEqual(result["retry_count"], 999)
+        result = task.build_result(prompt="overridden")
+        self.assertEqual(result["prompt"], "overridden")        # payload overrides data
+        self.assertEqual(result["retry_count"], "user-supplied")  # data survives at top level
+        self.assertEqual(result["task_metadata"]["retry_count"], 2)  # metadata is independent
+        self.assertEqual(result["task_metadata"]["success"], True)
 
-    def test_success_and_error_are_keyword_only(self):
+    def test_success_error_and_error_type_are_keyword_only(self):
         # Guards against positional misuse like build_result(False, "oops")
         # silently swapping argument meaning.
         task = _make_task()
@@ -366,7 +392,8 @@ class TestBuildResult(unittest.TestCase):
             task.build_result(False)  # type: ignore[misc]
         with self.assertRaises(TypeError):
             task.build_result(True, "oops")  # type: ignore[misc]
-
+        with self.assertRaises(TypeError):
+            task.build_result(True, None, "oops")  # type: ignore[misc]
 
 # ---------------------------------------------------------------------------
 # Exports for use in other test modules


### PR DESCRIPTION
## Summary

`Task.build_result()` (added in #70) mixed task bookkeeping (`success`, `error`, `retry_count`, `max_retries`) with the task's own output fields and the spread of `self.data`. In a real-world prompt-translation run, the output JSONL had `success` and `retry_count` sitting as siblings of `dataset`, `prompt`, `custom_id`, etc. — confusing for downstream consumers and a collision risk against any input data that happens to have a `success` or `retry_count` field.

This PR moves all bookkeeping under a single `task_metadata` key.

## Output shape

**Before:**
```json
{
  "dataset": [...],
  "prompt": "...",
  "translated_prompt": "...",
  "success": true,
  "retry_count": 0,
  "max_retries": 3
}
```

**After:**
```json
{
  "dataset": [...],
  "prompt": "...",
  "translated_prompt": "...",
  "task_metadata": {
    "success": true,
    "retry_count": 0,
    "max_retries": 3
  }
}
```

On failure (`success=False`), `task_metadata` also carries `error` and `error_type`:
```json
{
  "...input fields...": "...",
  "translated_prompt": "<partial output>",
  "task_metadata": {
    "success": false,
    "error": "Trace translation request failed: ...",
    "error_type": "traces_translation_error",
    "retry_count": 3,
    "max_retries": 3
  }
}
```

## Changes

- `dispatcher/taskmanager/task/base.py` — `build_result` now collects all bookkeeping under `task_metadata`. `error_type` is promoted from `**payload` to an explicit keyword argument so it stops leaking into the task's namespace.
- `tests/taskmanager/test_generator_task.py` — `TestBuildResult` rewritten to assert on the nested shape, plus a new test (`test_payload_and_data_do_not_collide_with_metadata`) that exercises the no-collision property: a task whose `self.data` already has a `retry_count` field keeps its value at the top level while `task_metadata.retry_count` independently holds the dispatcher value.

## Behavior change (worth flagging)

This is a **breaking change to the dispatcher result schema**. Anything parsing the flat shape — `result["success"]`, `result["retry_count"]`, etc. — needs to read `result["task_metadata"][...]` instead. The schema was only just introduced in #70, so no in-tree consumers depend on it yet. Tasks that hand-rolled their own dicts (returning `{**self.data, ...}` directly) are unaffected.

## Test plan

- [x] Full test suite passes (67 tests, including 9 updated `TestBuildResult` assertions).
- [ ] Manual: re-run the prompt-translation real-world test on `ex/backlog-inference` and verify both `success: true` and `success: false` rows land under `task_metadata`.