### PR TITLE
Rename README header to Preemptible (Backfill) Inference

### DIFF
--- a/examples/backlog_inference/README.md
+++ b/examples/backlog_inference/README.md
@@ -1,4 +1,4 @@
-# Dispatcher Inference Example
+# Preemptible (Backfill) Inference
 
 A shared example for running dispatcher-backed generation tasks over JSONL
 input. It covers plain OpenAI-messages inference, two flavors of reasoning-trace


### PR DESCRIPTION
## Summary

Renames `examples/backlog_inference/README.md`'s top-level heading from `# Dispatcher Inference Example` to `# Preemptible (Backfill) Inference` — clearer about what the example showcases, and fixes the typo from the earlier direct-to-master attempt (`Preemtible` was missing a `p`).

That earlier commit (`c845304`) was reset off master and is replaced by this PR.

## Test plan

- [x] Header rendered correctly locally (`head -1 examples/backlog_inference/README.md`).
- [ ] CI passes (no functional changes; README-only).