### PR TITLE
Add LUMI-native launch scripts for backlog_inference example

### DIFF
--- a/examples/backlog_inference/jobs/lumi/launch_dispatcher_server_lumi.sh
+++ b/examples/backlog_inference/jobs/lumi/launch_dispatcher_server_lumi.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+###############################################################################
+# launch_dispatcher_server_lumi.sh - LUMI version of launch_dispatcher_server.sh
+#
+# Runs the dispatcher server (a lightweight, CPU-only FastAPI process) as a
+# batch job instead of the login-node tmux flow used by
+# start_dispatcher_server.sh directly. Runs inside the LUMI AI Framework
+# container (via lumi_singularity_launcher.sh) so the server sees the same
+# Python environment as the workers.
+#
+# Usage:
+#   sbatch jobs/lumi/launch_dispatcher_server_lumi.sh [configs/your-server-config.conf]
+#
+# Note: LUMI has no CPU partition with a multi-day time limit like TW's
+# amd-tw-verification (10 days) -- `small` caps at 3 days. Long campaigns
+# will need to resubmit this job; start_dispatcher_server.sh's own
+# restart-on-exit loop and on-disk address/checkpoint files make that safe.
+###############################################################################
+
+#SBATCH --job-name=dispatcher-server
+#SBATCH --account=project_462001516
+#SBATCH --partition=small
+#SBATCH --time=3-00:00:00
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=64G
+#SBATCH --output=logs/dispatcher-server-%j.out
+#SBATCH --error=logs/dispatcher-server-%j.err
+
+set -euo pipefail
+loginctl enable-linger "$(id -un)" 2>/dev/null || true
+
+CONFIG_FILE="${1:-configs/dispatcher-server-sft-pipeline-stage5.conf}"
+WORK_DIR="${WORK_DIR:-$SLURM_SUBMIT_DIR}"
+cd "$WORK_DIR"
+
+LAUNCHER="${LAUNCHER:-$WORK_DIR/lumi_singularity_launcher.sh}"
+source "$LAUNCHER"
+
+echo "Starting dispatcher server (config: $CONFIG_FILE) on $(hostname)"
+run_sing_bash "cd '$WORK_DIR' && exec ./start_dispatcher_server.sh '$CONFIG_FILE' --run-server"

--- a/examples/backlog_inference/jobs/lumi/launch_dispatcher_worker_lumi.sh
+++ b/examples/backlog_inference/jobs/lumi/launch_dispatcher_worker_lumi.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+###############################################################################
+# launch_dispatcher_worker_lumi.sh - LUMI version of launch_dispatcher_worker.sh
+#
+# Single-node preemptable dispatcher worker running a vLLM instance against
+# the central dispatcher server. Uses LUMI's AI Framework (LAIFS) singularity
+# module + the lumi-multitorch-plus container (confirmed to bundle
+# vllm==0.20.1+lumi.aif.gfx90a) instead of TW's rocm_vllm/vllm-openai-rocm sif.
+#
+# When preempted, any in-flight work items time out on the server side and
+# are automatically reissued to another (or the same requeued) worker. No
+# data is lost.
+#
+# Usage:
+#   sbatch jobs/lumi/launch_dispatcher_worker_lumi.sh [configs/your-config.conf]
+#
+# To change GPU count per worker, override both the SBATCH allocation and
+# GPUS_PER_TASK together, e.g.:
+#   sbatch --gpus-per-node=8 --mem=480G \
+#     jobs/lumi/launch_dispatcher_worker_lumi.sh configs/your-config.conf
+#   (with GPUS_PER_TASK=8 set in the config file to match)
+#
+# If a config file is provided, it is sourced before applying defaults.
+# Config files are shell-sourceable files with KEY=VALUE pairs.
+###############################################################################
+
+#SBATCH --job-name=inference
+#SBATCH --account=project_462001516
+#SBATCH --partition=small-g
+#SBATCH --time=3-00:00:00
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=2
+#SBATCH --mem=120G
+#SBATCH --cpus-per-task=14
+#SBATCH --hint=nomultithread
+#SBATCH --output=logs/%A_%a.out
+#SBATCH --error=logs/%A_%a.err
+
+set -euo pipefail
+
+###############################################################################
+# Config file: source if provided as first argument
+###############################################################################
+
+CONFIG_FILE="${1:-}"
+
+# Resolve working directory (backlog_inference/)
+WORK_DIR="${WORK_DIR:-$SLURM_SUBMIT_DIR}"
+
+if [ -n "$CONFIG_FILE" ]; then
+  if [[ "$CONFIG_FILE" != /* ]]; then
+    CONFIG_FILE="$(cd "$(dirname "$CONFIG_FILE")" && pwd)/$(basename "$CONFIG_FILE")"
+  fi
+  if [ ! -f "$CONFIG_FILE" ]; then
+    echo "ERROR: Config file not found: $CONFIG_FILE" >&2
+    exit 1
+  fi
+  source "$CONFIG_FILE"
+fi
+
+###############################################################################
+# Configuration - defaults for anything not set by config file or environment
+###############################################################################
+
+LAUNCHER="${LAUNCHER:-$WORK_DIR/lumi_singularity_launcher.sh}"
+SERVER_ADDRESS_FILE="${SERVER_ADDRESS_FILE:-.dispatcher-server}"
+ADDRESS_FILE="$WORK_DIR/$SERVER_ADDRESS_FILE"
+
+# Dispatcher package source (mirrors start_dispatcher_server.sh). Default:
+# repo root two levels above WORK_DIR (examples/backlog_inference), so jobs
+# submitted from that dir pick up the in-tree dispatcher.
+DISPATCHER_PKG="${DISPATCHER_PKG:-$(cd "$WORK_DIR/../.." && pwd)}"
+
+# Skip pip install when dispatcher is already installed (avoids race conditions when
+# multiple workers share the same user site-packages). Set SKIP_DISPATCHER_INSTALL=1
+# to use pre-installed dispatcher (e.g. from a one-time setup job).
+SKIP_DISPATCHER_INSTALL="${SKIP_DISPATCHER_INSTALL:-1}"
+
+TASK=${TASK:-tasks.task.Task}
+
+MODEL=${MODEL:-/scratch/project_462001516/models/gemma-4-31B-it}
+GPUS_PER_TASK=${GPUS_PER_TASK:-1}
+LANGUAGE=${LANGUAGE:-}
+PROMPT_TRANSLATION_MAX_TOKENS=${PROMPT_TRANSLATION_MAX_TOKENS:-}
+TRACE_TRANSLATION_MAX_TOKENS=${TRACE_TRANSLATION_MAX_TOKENS:-}
+ANSWER_TRANSLATION_MAX_TOKENS=${ANSWER_TRANSLATION_MAX_TOKENS:-}
+GROUND_TRUTH_TRANSLATION_MAX_TOKENS=${GROUND_TRUTH_TRANSLATION_MAX_TOKENS:-}
+HIP_VISIBLE_DEVICES=${HIP_VISIBLE_DEVICES:-$(seq -s, 0 $((GPUS_PER_TASK - 1)))}
+VLLM_EXTRA_ARGS=${VLLM_EXTRA_ARGS:-}
+
+WORKERS=${WORKERS:-256}
+BATCH_SIZE=${BATCH_SIZE:-1}
+
+REQUEST_TIMEOUT=${REQUEST_TIMEOUT:-3600}
+STARTUP_TIMEOUT=${STARTUP_TIMEOUT:-7200}
+
+MAX_MODEL_LEN=${MAX_MODEL_LEN:-65536}
+
+###############################################################################
+# Resolve dispatcher server address
+###############################################################################
+
+if [ -z "${DISPATCHER_SERVER:-}" ] || [ -z "${DISPATCHER_PORT:-}" ]; then
+  if [ -f "$ADDRESS_FILE" ]; then
+    IFS=: read -r DISPATCHER_SERVER DISPATCHER_PORT < "$ADDRESS_FILE"
+    echo "Read dispatcher address from $ADDRESS_FILE: $DISPATCHER_SERVER:$DISPATCHER_PORT"
+  else
+    echo "ERROR: No dispatcher address found."
+    echo "Either set DISPATCHER_SERVER and DISPATCHER_PORT env vars,"
+    echo "or run start_dispatcher_server.sh / jobs/lumi/launch_dispatcher_server_lumi.sh first."
+    exit 1
+  fi
+fi
+
+export DISPATCHER_SERVER
+export DISPATCHER_PORT
+
+###############################################################################
+# Set up working directory and source launcher
+###############################################################################
+
+cd "$WORK_DIR"
+source "$LAUNCHER"
+
+###############################################################################
+# Wait for dispatcher server to be reachable
+###############################################################################
+
+echo "Connecting to dispatcher server at $DISPATCHER_SERVER:$DISPATCHER_PORT..."
+for i in $(seq 1 120); do
+  curl -sf -o /dev/null --max-time 2 "http://$DISPATCHER_SERVER:$DISPATCHER_PORT/status" && break || true
+  sleep 1
+done
+curl -sf -o /dev/null --max-time 2 "http://$DISPATCHER_SERVER:$DISPATCHER_PORT/status" || {
+  echo "[ERROR] Dispatcher server not reachable at $DISPATCHER_SERVER:$DISPATCHER_PORT"
+  exit 1
+}
+echo "Server is reachable."
+
+###############################################################################
+# Install dispatcher package in container (or skip if already installed)
+# When multiple workers run in parallel, they share the same user site-packages.
+# Concurrent pip install/uninstall causes race conditions (ModuleNotFoundError).
+# Use flock to serialize installs, or set SKIP_DISPATCHER_INSTALL=1 to skip.
+###############################################################################
+
+if [ "$SKIP_DISPATCHER_INSTALL" = "1" ]; then
+  echo "Skipping dispatcher install (SKIP_DISPATCHER_INSTALL=1). Adding $DISPATCHER_PKG to PYTHONPATH."
+  DISPATCHER_PYTHONPATH_EXTRA="$DISPATCHER_PKG"
+else
+  INSTALL_LOCK="$WORK_DIR/.dispatcher_install.lock"
+  echo "Installing dispatcher package from $DISPATCHER_PKG (lock: $INSTALL_LOCK)..."
+  (
+    flock -x -w 300 9 || { echo "[ERROR] Failed to acquire install lock"; exit 1; }
+    run_sing_python -m pip install --user -e "$DISPATCHER_PKG"
+  ) 9>"$INSTALL_LOCK"
+  echo "Dispatcher install complete."
+  DISPATCHER_PYTHONPATH_EXTRA=""
+fi
+
+###############################################################################
+# Derive vLLM / MASTER ports from the physical GPU ID assigned by SLURM.
+###############################################################################
+
+GPU_ID="${SLURM_JOB_GPUS%%,*}"
+if [ -z "$GPU_ID" ]; then
+  echo "[ERROR] SLURM_JOB_GPUS is empty; cannot derive a deterministic port." >&2
+  exit 1
+fi
+
+VLLM_PORT=$((20000 + GPU_ID * 100))
+MASTER_PORT=$((19000 + GPU_ID * 100))
+
+if [ -n "$(ss -Hltn "sport = :$VLLM_PORT" 2>/dev/null)" ]; then
+  echo "[ERROR] Port $VLLM_PORT already in use on $(hostname); refusing to start." >&2
+  exit 1
+fi
+
+###############################################################################
+# Run worker in container
+#
+# Signal handling for preemption:
+# Singularity tears down the container (including network) when it receives
+# SIGTERM directly, which prevents the Python signal handler from POST-ing
+# /release.  We use job control (set -m) to run the worker in its own process
+# group so SLURM's SIGTERM only hits the outer bash.  The trap forwards SIGTERM
+# to the worker process group, and the inner bash ignores it so only Python
+# handles the signal while the container is still alive.
+###############################################################################
+
+_CHILD_PID=
+trap '[ -n "$_CHILD_PID" ] && { kill -TERM -- -"$_CHILD_PID" 2>/dev/null; wait "$_CHILD_PID" 2>/dev/null; }' TERM INT
+
+set -m
+run_sing_bash "
+  set -uo pipefail
+  trap : TERM HUP
+  DISPATCHER_PYTHONPATH_EXTRA=\"$DISPATCHER_PYTHONPATH_EXTRA\"
+  if [ -n \"\$DISPATCHER_PYTHONPATH_EXTRA\" ]; then
+    export PYTHONPATH=\"\$DISPATCHER_PYTHONPATH_EXTRA\":\${PYTHONPATH:-}
+  fi
+
+  export HIP_VISIBLE_DEVICES=\"$HIP_VISIBLE_DEVICES\"
+  export LANGUAGE=\"$LANGUAGE\"
+  export MODEL=\"$MODEL\"
+  [ -n \"$PROMPT_TRANSLATION_MAX_TOKENS\" ] && export PROMPT_TRANSLATION_MAX_TOKENS=\"$PROMPT_TRANSLATION_MAX_TOKENS\"
+  [ -n \"$TRACE_TRANSLATION_MAX_TOKENS\" ] && export TRACE_TRANSLATION_MAX_TOKENS=\"$TRACE_TRANSLATION_MAX_TOKENS\"
+  [ -n \"$ANSWER_TRANSLATION_MAX_TOKENS\" ] && export ANSWER_TRANSLATION_MAX_TOKENS=\"$ANSWER_TRANSLATION_MAX_TOKENS\"
+  [ -n \"$GROUND_TRUTH_TRANSLATION_MAX_TOKENS\" ] && export GROUND_TRUTH_TRANSLATION_MAX_TOKENS=\"$GROUND_TRUTH_TRANSLATION_MAX_TOKENS\"
+  VLLM_EXTRA_ARGS=\"$VLLM_EXTRA_ARGS\"
+
+  export MASTER_ADDR=\${MASTER_ADDR:-127.0.0.1}
+  export MASTER_PORT=$MASTER_PORT
+  export VLLM_PORT=$VLLM_PORT
+
+  VLLM_ARGS=()
+  if [ -n \"\$VLLM_EXTRA_ARGS\" ]; then
+    VLLM_ARGS=(--vllm-extra-args \"\$VLLM_EXTRA_ARGS\")
+  fi
+
+  echo \"Launching worker on \$(hostname) with GPUs \$HIP_VISIBLE_DEVICES (job \${SLURM_JOB_ID:-unknown})\"
+
+  run_python -m dispatcher.taskmanager.cli \
+    --dispatcher $DISPATCHER_SERVER:$DISPATCHER_PORT \
+    --task $TASK \
+    --batch-size $BATCH_SIZE \
+    --workers $WORKERS \
+    --max-model-len $MAX_MODEL_LEN \
+    --tensor-parallel $GPUS_PER_TASK \
+    --model $MODEL \
+    --port \$VLLM_PORT \
+    --request-timeout $REQUEST_TIMEOUT \
+    --startup-timeout $STARTUP_TIMEOUT \
+    \"\${VLLM_ARGS[@]}\" " &
+
+_CHILD_PID=$!
+# Double-wait idiom: when a signal interrupts the first wait, it returns
+# 128+signum (not the child's real status) and the trap fires.  The second
+# wait then retrieves the child's actual exit status from bash's cache.
+wait "$_CHILD_PID" 2>/dev/null
+wait "$_CHILD_PID" 2>/dev/null

--- a/examples/backlog_inference/lumi_singularity_launcher.sh
+++ b/examples/backlog_inference/lumi_singularity_launcher.sh
@@ -1,0 +1,228 @@
+#!/bin/bash
+# Launcher library for SLURM jobs with Singularity containers on LUMI
+# Source this file in your SLURM job scripts to avoid duplicating container setup code
+#
+# LUMI equivalent of tw_singularity_launcher.sh. Differences from the TW version:
+#   - loads the LUMI AI Framework (LAIFS) module + lumi-multitorch container
+#     instead of the TW rocm_vllm/vllm-openai-rocm sif
+#   - binds LUMI's Lustre tiers (/scratch,/project,/flash,/pfs,...) 1:1 (no
+#     path remapping to /workspace) instead of TW's /shared_silo/scratch paths
+#   - no --rocm flag on singularity exec / no AITER JIT patching: LUMI's
+#     lumi-aif-singularity-bindings module handles ROCm device/library binds,
+#     and AITER's JIT install-root hack in the TW launcher is a workaround
+#     specific to MI300 (gfx942); LUMI is MI250x (gfx90a) and doesn't need it
+#   - no hardcoded SINGULARITYENV_PATH: the container's own PATH is used as-is
+
+###############################################################################
+# Configuration Variables (can be overridden before sourcing this file)
+###############################################################################
+
+: "${LAUNCHER_IMG:=/appl/local/laifs/containers/lumi-multitorch-u24r70f21m50t210-20260807_115122/lumi-multitorch-plus-u24r70f21m50t210-20260807_115122.sif}"
+: "${LAUNCHER_PYEXEC_IN_IMG:=python3}"
+: "${LAUNCHER_PYTHON_VERSION:=3.12}"
+: "${LAUNCHER_HF_HOME:=/scratch/project_462001516/users/zosaelai2/hf-home}"
+: "${LAUNCHER_TORCHINDUCTOR_CACHE:=/tmp/$USER/$SLURM_JOB_ID/torch_inductor_cache}"
+: "${LAUNCHER_BIND_DIRS:=/pfs,/scratch,/projappl,/project,/flash,/appl,/opt/cray,/var/spool/slurmd}"
+
+# Offline mode flags (set to empty string to disable)
+: "${LAUNCHER_HF_HUB_OFFLINE:=}"
+: "${LAUNCHER_TRANSFORMERS_OFFLINE:=}"
+
+###############################################################################
+# setup_singularity_environment()
+# Loads the LAIFS module (which wires up ROCm device/library binds for
+# singularity) and sets up all environment variables and paths for container
+# execution.
+###############################################################################
+setup_singularity_environment() {
+  module purge
+  module use /appl/local/laifs/modules
+  module load lumi-aif-singularity-bindings
+
+  mkdir -p logs pythonuserbase
+
+  # Caches MUST be on writable, node-local paths. Scope them by user and
+  # Slurm job so stale cache parents from other users cannot block mkdir.
+  export HF_HOME="$LAUNCHER_HF_HOME"
+  export TRANSFORMERS_CACHE="$HF_HOME"
+  export TORCHINDUCTOR_CACHE="$LAUNCHER_TORCHINDUCTOR_CACHE"
+  install -d -m 700 "/tmp/$USER/$SLURM_JOB_ID" "/dev/shm/$USER/$SLURM_JOB_ID"
+  mkdir -p "$HF_HOME" "$TORCHINDUCTOR_CACHE"
+
+  if [ -n "$LAUNCHER_HF_HUB_OFFLINE" ]; then
+    export HF_HUB_OFFLINE="$LAUNCHER_HF_HUB_OFFLINE"
+  fi
+  if [ -n "$LAUNCHER_TRANSFORMERS_OFFLINE" ]; then
+    export TRANSFORMERS_OFFLINE="$LAUNCHER_TRANSFORMERS_OFFLINE"
+  fi
+
+  export IMG="$LAUNCHER_IMG"
+  export PYEXEC_IN_IMG="$LAUNCHER_PYEXEC_IN_IMG"
+  export PIP_IN_IMG="$PYEXEC_IN_IMG -m pip"
+
+  export PYUSERBASE="$PWD/pythonuserbase"
+  export PYUSERPKG="$PYUSERBASE/lib/python${LAUNCHER_PYTHON_VERSION}/site-packages"
+
+  # HF token: read from env, then fall back to the default cached token file
+  if [ -z "${HF_TOKEN:-}" ]; then
+    local _token_file="$HOME/.cache/huggingface/token"
+    if [ -f "$_token_file" ]; then
+      HF_TOKEN="$(cat "$_token_file")"
+    fi
+  fi
+  if [ -n "${HF_TOKEN:-}" ]; then
+    { set +x; } 2>/dev/null
+    export SINGULARITYENV_HF_TOKEN="$HF_TOKEN"
+    set -x
+  fi
+
+  # Pass all required ENVs into the container
+  export SINGULARITYENV_USER="$USER"
+  export SINGULARITYENV_HF_HOME="$HF_HOME"
+  export SINGULARITYENV_TRANSFORMERS_CACHE="$TRANSFORMERS_CACHE"
+  export SINGULARITYENV_TORCHINDUCTOR_CACHE="$TORCHINDUCTOR_CACHE"
+  export SINGULARITYENV_PYTHONUSERBASE="$PYUSERBASE"
+  export SINGULARITYENV_PYTHONPATH="$PYUSERPKG:\${PYTHONPATH-}"
+  export SINGULARITYENV_PYEXEC_IN_IMG="$PYEXEC_IN_IMG"
+  export SINGULARITYENV_DISPATCHER_SERVER="${DISPATCHER_SERVER:-}"
+  export SINGULARITYENV_DISPATCHER_PORT="${DISPATCHER_PORT:-}"
+
+  if [ -n "${HF_HUB_OFFLINE:-}" ]; then
+    export SINGULARITYENV_HF_HUB_OFFLINE="$HF_HUB_OFFLINE"
+  fi
+  if [ -n "${TRANSFORMERS_OFFLINE:-}" ]; then
+    export SINGULARITYENV_TRANSFORMERS_OFFLINE="$TRANSFORMERS_OFFLINE"
+  fi
+
+  # vLLM/ROCm flags (LUMI is gfx90a / MI250x -- no AITER, no gfx942 pin)
+  export SINGULARITYENV_VLLM_USE_V1=${VLLM_USE_V1:-1}
+  export SINGULARITYENV_VLLM_TARGET_DEVICE=rocm
+  export SINGULARITYENV_VLLM_WORKER_MULTIPROC_METHOD=spawn
+
+  export SINGULARITYENV_TORCH_EXTENSIONS_DIR="/dev/shm/$USER/$SLURM_JOB_ID/torch_ext"
+  export SINGULARITYENV_PYTHONNOUSERSITE=
+}
+
+###############################################################################
+# get_binds
+# Returns bind mount arguments as an array. LUMI containers expect host paths
+# bound 1:1 (no /workspace remap) -- matches the pattern used by
+# train-gpt-prelude-iter0830400-128k-packed.sh.
+###############################################################################
+get_binds() {
+  local binds=(
+    -B "${PWD:-$(pwd)}"
+    -B "$LAUNCHER_BIND_DIRS"
+  )
+  printf '%s\n' "${binds[@]}"
+}
+export -f get_binds
+
+###############################################################################
+# setup_cleanup_trap
+###############################################################################
+setup_cleanup_trap() {
+  trap 'kill "${srv_pid:-0}" 2>/dev/null || true' EXIT
+}
+
+###############################################################################
+# translate_slurm_vars
+# Translates SLURM_* environment variables to SINGULARITYENV_* versions
+# so they pass through --cleanenv
+###############################################################################
+translate_slurm_vars() {
+  local var
+  for var in SLURM_PROCID SLURM_LOCALID SLURM_STEP_ID SLURM_STEP_TASK_ID SLURM_JOB_ID SLURM_NODEID SLURM_NTASKS SLURM_JOB_GPUS; do
+    if [ -n "${!var:-}" ]; then
+      export "SINGULARITYENV_${var}=${!var}"
+    fi
+  done
+}
+export -f translate_slurm_vars
+
+###############################################################################
+# Complete environment setup
+###############################################################################
+setup_launcher_environment() {
+  translate_slurm_vars
+  setup_singularity_environment
+  setup_cleanup_trap
+}
+
+###############################################################################
+# run_sing_bash
+# Helper function to run bash commands inside the Singularity container
+# Usage: run_sing_bash "command to run"
+###############################################################################
+run_sing_bash() {
+  [ -n "${IMG:-}" ] || {
+    echo "[lumi_singularity_launcher] ERROR: run_sing_bash called before setup_singularity_environment" >&2
+    return 1
+  }
+  translate_slurm_vars
+  local binds_array
+  mapfile -t binds_array < <(get_binds)
+  local env_setup="
+    export HOME=\"$PWD\"
+
+    export HF_HOME=\"\${HF_HOME:-}\"
+    export TRANSFORMERS_CACHE=\"\${TRANSFORMERS_CACHE:-}\"
+    export TORCHINDUCTOR_CACHE=\"\${TORCHINDUCTOR_CACHE:-}\"
+    export HF_HUB_OFFLINE=\"\${HF_HUB_OFFLINE:-}\"
+    export TRANSFORMERS_OFFLINE=\"\${TRANSFORMERS_OFFLINE:-}\"
+    export PYEXEC_IN_IMG=\"\${PYEXEC_IN_IMG:-}\"
+
+    export PYTHONUSERBASE=\"\${PYTHONUSERBASE:-$PWD/pythonuserbase}\"
+    export PATH=\"\$PYTHONUSERBASE/bin:\$PATH\"
+    export PYTHONPATH=\"\$PYTHONUSERBASE/lib/python${LAUNCHER_PYTHON_VERSION}/site-packages:\${PYTHONPATH-}\"
+    export PYTHONNOUSERSITE=
+
+    export VLLM_USE_V1=\${VLLM_USE_V1:-1}
+    export VLLM_TARGET_DEVICE=\${VLLM_TARGET_DEVICE:-rocm}
+    export VLLM_WORKER_MULTIPROC_METHOD=\${VLLM_WORKER_MULTIPROC_METHOD:-spawn}
+
+    # Triton cache isolation (avoid multi-rank races on shared filesystems)
+    export TRITON_CACHE_DIR=\"/tmp/\$USER/\$SLURM_JOB_ID/triton_cache/\${SLURM_PROCID:-\${SLURM_LOCALID:-0}}\"
+    export XDG_CACHE_HOME=\"/tmp/\$USER/\$SLURM_JOB_ID/xdg_cache/\${SLURM_PROCID:-\${SLURM_LOCALID:-0}}\"
+    mkdir -p \"\$TRITON_CACHE_DIR\" \"\$XDG_CACHE_HOME\" 2>/dev/null || true
+
+    export TORCH_EXTENSIONS_DIR=\"\${TORCH_EXTENSIONS_DIR:-/dev/shm/\$USER/\$SLURM_JOB_ID/torch_ext}\"
+    mkdir -p \"\$TORCH_EXTENSIONS_DIR\" 2>/dev/null || true
+
+    run_python() {
+      \"\${PYEXEC_IN_IMG:-python3}\" \"\$@\"
+    }
+  "
+  if [ $# -eq 0 ]; then
+    echo "[lumi_singularity_launcher] ERROR: run_sing_bash called without command" >&2
+    return 1
+  fi
+  local user_command="$*"
+  local full_command="$env_setup
+$user_command"
+  singularity exec --cleanenv "${binds_array[@]}" "$IMG" bash --noprofile --norc -c "$full_command"
+}
+export -f run_sing_bash
+
+###############################################################################
+# run_sing_python
+###############################################################################
+run_sing_python() {
+  [ -n "${IMG:-}" ] && [ -n "${PYEXEC_IN_IMG:-}" ] || {
+    echo "[lumi_singularity_launcher] ERROR: run_sing_python called before setup_singularity_environment" >&2
+    return 1
+  }
+  local binds_array
+  mapfile -t binds_array < <(get_binds)
+  singularity exec --cleanenv "${binds_array[@]}" "$IMG" "$PYEXEC_IN_IMG" "$@"
+}
+
+###############################################################################
+# is_inside_container
+###############################################################################
+is_inside_container() {
+  [ -n "${SINGULARITY_NAME:-}" ] || [ -f /.singularity.d/env/99-base.sh ]
+}
+
+# Run this when the script is sourced in the launcher
+setup_launcher_environment


### PR DESCRIPTION
## Summary
- Adds LUMI-native equivalents of the existing TW-cluster launch infrastructure for the `backlog_inference` example, adapted for LUMI's LAIFS module system and gfx90a (MI250x) hardware.
- `lumi_singularity_launcher.sh` loads the `lumi-aif-singularity-bindings` module (auto-binds `/scratch,/project,/flash,/pfs`) instead of TW's `--rocm` flag / AITER JIT patching.
- `jobs/lumi/launch_dispatcher_server_lumi.sh` runs the CPU-only dispatcher server on LUMI's `small` partition (3-day cap vs. TW's 10-day `amd-tw-verification`).
- `jobs/lumi/launch_dispatcher_worker_lumi.sh` runs the GPU worker on `small-g`, sized to LUMI's 8-GCD-per-node topology, with per-GPU vLLM/MASTER port derivation and preemption-safe SIGTERM forwarding.
- Validated end-to-end against a live dispatcher server/worker pipeline (`gemma-4-31B-it`, tensor-parallel=2 across 2 MI250x GCDs) processing real translation tasks.

## Test plan
- [x] Dispatcher server launched via `jobs/lumi/launch_dispatcher_server_lumi.sh` on LUMI's `small` partition.
- [x] Dispatcher worker launched via `jobs/lumi/launch_dispatcher_worker_lumi.sh` on `dev-g` and `small-g`, tensor-parallel=2.
- [x] Confirmed real successful task completions (non-empty, correctly formatted model outputs) round-tripped through the dispatcher.