### PR TITLE
Allow explicit LUMI env passthrough with cleanenv

### DIFF
--- a/examples/backlog_inference/jobs/lumi/launch_dispatcher_server_lumi.sh
+++ b/examples/backlog_inference/jobs/lumi/launch_dispatcher_server_lumi.sh
@@ -34,6 +34,7 @@ WORK_DIR="${WORK_DIR:-$SLURM_SUBMIT_DIR}"
 cd "$WORK_DIR"
 
 LAUNCHER="${LAUNCHER:-$WORK_DIR/lumi_singularity_launcher.sh}"
+LAUNCHER_PASSTHROUGH_VARS="${LAUNCHER_PASSTHROUGH_VARS:-} OUTPUT_FILE DISPATCHER_PORT SESSION_NAME"
 source "$LAUNCHER"
 
 echo "Starting dispatcher server (config: $CONFIG_FILE) on $(hostname)"

--- a/examples/backlog_inference/lumi_singularity_launcher.sh
+++ b/examples/backlog_inference/lumi_singularity_launcher.sh
@@ -23,6 +23,7 @@
 : "${LAUNCHER_HF_HOME:=/scratch/project_462001516/users/zosaelai2/hf-home}"
 : "${LAUNCHER_TORCHINDUCTOR_CACHE:=/tmp/$USER/$SLURM_JOB_ID/torch_inductor_cache}"
 : "${LAUNCHER_BIND_DIRS:=/pfs,/scratch,/projappl,/project,/flash,/appl,/opt/cray,/var/spool/slurmd}"
+: "${LAUNCHER_PASSTHROUGH_VARS:=}"
 
 # Offline mode flags (set to empty string to disable)
 : "${LAUNCHER_HF_HUB_OFFLINE:=}"
@@ -85,7 +86,19 @@ setup_singularity_environment() {
   export SINGULARITYENV_PYTHONPATH="$PYUSERPKG:\${PYTHONPATH-}"
   export SINGULARITYENV_PYEXEC_IN_IMG="$PYEXEC_IN_IMG"
   export SINGULARITYENV_DISPATCHER_SERVER="${DISPATCHER_SERVER:-}"
-  export SINGULARITYENV_DISPATCHER_PORT="${DISPATCHER_PORT:-}"
+
+  # Keep --cleanenv while allowing each job to explicitly opt selected host
+  # variables into the container environment.
+  local passthrough_var
+  for passthrough_var in $LAUNCHER_PASSTHROUGH_VARS; do
+    if [[ ! "$passthrough_var" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      echo "Invalid LAUNCHER_PASSTHROUGH_VARS entry: $passthrough_var" >&2
+      return 1
+    fi
+    if declare -p "$passthrough_var" &>/dev/null; then
+      export "SINGULARITYENV_${passthrough_var}=${!passthrough_var}"
+    fi
+  done
 
   if [ -n "${HF_HUB_OFFLINE:-}" ]; then
     export SINGULARITYENV_HF_HUB_OFFLINE="$HF_HUB_OFFLINE"


### PR DESCRIPTION
## Summary

- add an explicit launcher allowlist for forwarding selected host variables into Singularity
- keep `singularity exec --cleanenv` while passing dispatcher output, port, and session overrides
- replace the hard-coded dispatcher port forwarding with the reusable pass-through mechanism

## Validation

- `bash -n` on both modified shell scripts
- `git diff --check`
- verified the allowlist exports the expected `SINGULARITYENV_*` variables
- exercised on LUMI with six healthy dispatcher servers and 24 running translation workers
